### PR TITLE
PR: Add event handling to the caching client and add custom logic as needed

### DIFF
--- a/cachingClient/README.md
+++ b/cachingClient/README.md
@@ -22,6 +22,12 @@ Caching Client (HTTP Client using the Cache API).
 
 To build a lib to be used in the browser you can use `npm run build:lib` this will create the `index.js` file that can be used from an HTML file with a script tag like `<script type="text/javascript" src="index.js"></script>`
 
+## Use the package
+
+To use the package you need to install it from the source with something like `npm install --save <path to source>`
+
+After that, you can use something like `import CachingClient from 'caching-client'`
+
 ## Demo Setup
 To play with the caching client you can use the [`http-server`](https://www.npmjs.com/package/http-server) package:
 

--- a/cachingClient/README.md
+++ b/cachingClient/README.md
@@ -1,9 +1,11 @@
 # Caching Client
 
-Example Caching Client (HTTP Client using the Cache API). This example cache any request that is made using the available functions.
+Example Caching Client (HTTP Client using the Cache API). This example caches the requests made using the available functions.
 
 ## Available functions
 
+* `constructor`: Doing `new CachingClient` you can pass the following options:
+    *  
 * `clearCache`: Removes any entry in the managed cache store.
 * `clearUnknownCache`: Removes any entry in caches not being managed by the client.
 * Requests (`GET`, `OPTIONS`, `POST`, `PUT`, `DELETE`): Each request can be used calling its respective function (i.e `get(...)`, `options(...)`, `post(...)`, `put(...)`, and `delete(...)`).
@@ -11,11 +13,16 @@ Example Caching Client (HTTP Client using the Cache API). This example cache any
     The parameters for the available functions are:
     * `url`: URL to fetch.
     * `body`: Content of the request (in the case of `POST` or `PUT` requests).
-    * `json`: If only the JSON parsed response is needed.
-    * `options`: To add or override the options used to fetch the given URL (`headers`, `mode`, `method`, etc.).
+    * `options`: To add or override the options used to fetch the given URL (`headers`, `mode`, `method`, etc.). Also you can add a `json` option if what you want to be return is the JSON parsed body of the response.
 
-## Setup
-To play with it you can use the [`http-server`](https://www.npmjs.com/package/http-server) package:
+
+## Build lib
+
+To build a lib to be used in the browser you can use `npm run build:lib` this wil create the `index.js` file that can be used from an html file with a script tag like `<script type="text/javascript" src="index.js"></script>`
+
+
+## Example Setup
+To play with the caching client you can use the [`http-server`](https://www.npmjs.com/package/http-server) package:
 
 ```
 npm install http-server -g
@@ -27,29 +34,21 @@ And under the `demo` directory:
 http-server -p 3000
 ```
 
+To build the demo after doing changes to the source code you can run `npm run build:demo`
+
 ## Example
 
+* Follow the setup above.
 * Go to http://localhost:3000
 * Open the console in your browser.
+* Create an instance of the Caching Client: `client = cachingClient.default()` 
 * Run something like `await cachingClient.get("https://jsonplaceholder.typicode.com/users/1/todos", true)`.
-    * Result without cache:
-        ```js
-        No response for https://jsonplaceholder.typicode.com/users/1/todos found in cache. About to fetch from network...
-        Response for https://jsonplaceholder.typicode.com/users/1/todos from network is:  
-        Response { type: "cors", url: "https://jsonplaceholder.typicode.com/users/1/todos", redirected: false, status: 200, ok: true, statusText: "OK", headers: Headers, body: ReadableStream, bodyUsed: false }
-        Array(20) [ {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, … ]
-        ```
-    * Result with cache:
-        ```js
-        Found response in cache: 
-        Response { type: "cors", url: "https://jsonplaceholder.typicode.com/users/1/todos", redirected: false, status: 200, ok: true, statusText: "OK", headers: Headers, body: ReadableStream, bodyUsed: false }
-        Array(20) [ {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, … ]  
-        ```
-## Resources
+* Check with the browser devtools the Cache Storage section (in the case of Mozilla to update the cache view you need to close and reopen the devtool panel).
 
-Based on:
+## Resources checked
 
 * https://jasonwatmore.com/post/2020/04/18/fetch-a-lightweight-fetch-wrapper-to-simplify-http-requests
 * https://github.com/GoogleChrome/samples/tree/gh-pages/service-worker/read-through-caching
+* https://gist.github.com/niallo/3109252#gistcomment-2883309
+* https://stackoverflow.com/a/58209729
  
-

--- a/cachingClient/README.md
+++ b/cachingClient/README.md
@@ -1,11 +1,14 @@
 # Caching Client
 
-Example Caching Client (HTTP Client using the Cache API). This example caches the requests made using the available functions.
+Caching Client (HTTP Client using the Cache API).
 
 ## Available functions
 
 * `constructor`: Doing `new CachingClient` you can pass the following options:
-    *  
+    * `cacheVersion`: Default 1
+    * `currentCache`: Default 'read-through'
+    * `jsonSchemaRelHeader`: Default 'rel=\'describedBy\''
+    * `jsonSchemaEnvelopType`: Default 'https://api.openteams.com/json-schema/Envelope'
 * `clearCache`: Removes any entry in the managed cache store.
 * `clearUnknownCache`: Removes any entry in caches not being managed by the client.
 * Requests (`GET`, `OPTIONS`, `POST`, `PUT`, `DELETE`): Each request can be used calling its respective function (i.e `get(...)`, `options(...)`, `post(...)`, `put(...)`, and `delete(...)`).
@@ -13,15 +16,13 @@ Example Caching Client (HTTP Client using the Cache API). This example caches th
     The parameters for the available functions are:
     * `url`: URL to fetch.
     * `body`: Content of the request (in the case of `POST` or `PUT` requests).
-    * `options`: To add or override the options used to fetch the given URL (`headers`, `mode`, `method`, etc.). Also you can add a `json` option if what you want to be return is the JSON parsed body of the response.
-
+    * `options`: To add or override the options used to fetch the given URL (`headers`, `mode`, `method`, etc.). Also you can add a `json` option if what you want get the response as the JSON parsed body.
 
 ## Build lib
 
-To build a lib to be used in the browser you can use `npm run build:lib` this wil create the `index.js` file that can be used from an html file with a script tag like `<script type="text/javascript" src="index.js"></script>`
+To build a lib to be used in the browser you can use `npm run build:lib` this will create the `index.js` file that can be used from an HTML file with a script tag like `<script type="text/javascript" src="index.js"></script>`
 
-
-## Example Setup
+## Demo Setup
 To play with the caching client you can use the [`http-server`](https://www.npmjs.com/package/http-server) package:
 
 ```
@@ -36,7 +37,7 @@ http-server -p 3000
 
 To build the demo after doing changes to the source code you can run `npm run build:demo`
 
-## Example
+## Demo
 
 * Follow the setup above.
 * Go to http://localhost:3000

--- a/cachingClient/demo/index.html
+++ b/cachingClient/demo/index.html
@@ -22,7 +22,8 @@
         For example you can try in the console:
         <p>
             <code>
-                await cachingClient.cachingClient.get("https://jsonplaceholder.typicode.com/users/1/todos", true)
+                client = new cachingClient.default();
+                await client.get("https://jsonplaceholder.typicode.com/users/1/todos", true);
             </code>
         </p>
         To check a dummy JSON of a list of todos.
@@ -31,7 +32,7 @@
         Also, you can use:
         <p>
             <code>
-                await cachingClient.cachingClient.clearCache();
+                await client.clearCache();
             </code>
         </p>
         To clear/empty the cache.

--- a/cachingClient/demo/index.html
+++ b/cachingClient/demo/index.html
@@ -23,7 +23,9 @@
         <p>
             <code>
                 client = new cachingClient.default();
-                await client.get("https://jsonplaceholder.typicode.com/users/1/todos", true);
+            </code>
+            <code>
+                await client.get("https://jsonplaceholder.typicode.com/users/1/todos", {json:true});
             </code>
         </p>
         To check a dummy JSON of a list of todos.

--- a/cachingClient/demo/index.js
+++ b/cachingClient/demo/index.js
@@ -28,14 +28,70 @@
   // * https://jasonwatmore.com/post/2020/04/18/fetch-a-lightweight-fetch-wrapper-to-simplify-http-requests
   // * https://github.com/GoogleChrome/samples/tree/gh-pages/service-worker/read-through-caching
   // * https://gist.github.com/niallo/3109252#gistcomment-2883309
-  // ----- Constants and values (probably need to be configurable)
-  class CachingClient extends EventTarget {
-    constructor(cache_version = 1, current_cache = 'read-through', json_schema_rel_header = 'rel=\'describedBy\'', json_schema_envelop_type = 'https://api.openteams.com/json-schema/Envelope') {
+  // * https://stackoverflow.com/a/58209729
+  // Class definitions (CachingClient and EventDispatcher)
+  // Needed for compatibility with Safari and Explorer since EventTarget there doesn't support the constructor.
+  // Taken from: https://stackoverflow.com/a/58209729
+  class EventDispatcher {
+    constructor() {
+      this._listeners = [];
+    }
+
+    hasEventListener(type, listener) {
+      return this._listeners.some(item => item.type === type && item.listener === listener);
+    }
+
+    addEventListener(type, listener) {
+      if (!this.hasEventListener(type, listener)) {
+        this._listeners.push({
+          type,
+          listener,
+          options: {
+            once: false
+          }
+        });
+      }
+
+      return this;
+    }
+
+    removeEventListener(type, listener) {
+      let index = this._listeners.findIndex(item => item.type === type && item.listener === listener);
+
+      if (index >= 0) this._listeners.splice(index, 1);
+      return this;
+    }
+
+    removeEventListeners() {
+      this._listeners = [];
+      return this;
+    }
+
+    dispatchEvent(evt) {
+      this._listeners.filter(item => item.type === evt.type).forEach(item => {
+        const {
+          type,
+          listener,
+          options: {
+            once
+          }
+        } = item;
+        listener.call(this, evt);
+        if (once === true) this.removeEventListener(type, listener);
+      });
+
+      return this;
+    }
+
+  }
+
+  class CachingClient extends EventDispatcher {
+    constructor(cacheVersion = 1, currentCache = 'read-through', jsonSchemaRelHeader = 'rel=\'describedBy\'', jsonSchemaEnvelopType = 'https://api.openteams.com/json-schema/Envelope') {
       super();
 
       _defineProperty(this, "clearUnknownCache", async () => {
-        const expectedCacheNames = Object.keys(this.current_caches).map(function (key) {
-          return this.current_caches[key];
+        const expectedCacheNames = Object.keys(this.currentCaches).map(function (key) {
+          return this.currentCaches[key];
         });
         const cacheNames = await caches.keys();
         return Promise.all(cacheNames.map(function (cacheName) {
@@ -48,23 +104,29 @@
       });
 
       _defineProperty(this, "clearCache", async () => {
-        return await caches.delete(this.current_caches[this.current_cache]);
+        return await caches.delete(this.currentCaches[this.currentCache]);
       });
 
       _defineProperty(this, "cacheRequest", async request => {
-        const cache = await caches.open(this.current_caches[this.current_cache]);
-        let cacheResponse = await cache.match(request.url);
+        const cache = await caches.open(this.currentCaches[this.currentCache]);
+        const cachedResponse = await cache.match(request.url);
 
-        if (cacheResponse) {
+        if (cachedResponse) {
           // If there is an entry in the cache for request.url, then response will be defined
           // and we can just return it for now.
-          // TODO: Add a way to check if an update to the cache is needed
           // e.g do a HEAD request to check cache headers for the resource.
-          // console.log(' Found response in cache:', cacheResponse);
-          return cacheResponse;
-        } // Otherwise, if there is no entry in the cache for request.url, response will be
-        // undefined, and we need to fetch() the resource.
-        // console.log(' No response for %s found in cache. ' + 'About to fetch from network...', request.url);
+          // console.log(' Found response in cache:', cachedResponse);
+          // TODO: Add a way to check if an update to the cache is needed
+          const headResponse = await fetch(request.url, {
+            method: this.HEAD
+          });
+
+          if (this._cacheUpToDate(headResponse, cachedResponse)) {
+            return cachedResponse;
+          }
+        } // Otherwise, if there is no entry in the cache for request.url or it needs to be updated, response will be
+        // undefined or old, and we need to fetch() the resource.
+        // console.log(' No response for %s found in cache or response stored is old. ' + 'About to fetch from network...', request.url);
         // We call .clone() on the request since we might use it in the call to cache.put() later on.
         // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
         // (see https://fetch.spec.whatwg.org/#dom-request-clone)
@@ -83,51 +145,70 @@
           //
           // We need to call .clone() on the response object to save a copy of it to the cache.
           // (https://fetch.spec.whatwg.org/#dom-request-clone)
-          const unwrappResources = await this._getUnwrappedResources(fetchResponse.clone());
+          const unwrappedResources = await this._getUnwrappedResources(fetchResponse.clone());
 
-          if (unwrappResources.length > 0) {
-            // Get Headers and content from response body, get response read-only values,
-            // cache response content with the headers extracted and values found.
-            for (const unwrappResource of unwrappResources) {
-              const {
-                ok,
-                redirected,
-                status,
-                statusText
-              } = fetchResponse;
-              const {
-                headers,
-                body,
-                url
-              } = unwrappResource;
-              const unWrappResponse = new Response(body, {
-                headers,
-                status,
-                statusText,
-                url
-              }); // Set response read only values that aren't available in the Response constructor.
-
-              Object.defineProperty(unWrappResponse, 'url', {
-                value: url
-              });
-              Object.defineProperty(unWrappResponse, 'ok', {
-                value: ok
-              });
-              Object.defineProperty(unWrappResponse, 'redirected', {
-                value: redirected
-              });
-              cache.put(url, unWrappResponse);
-            }
+          if (unwrappedResources.length > 0) {
+            this._cacheUnwrappedResources(unwrappedResources, fetchResponse, cache);
           }
 
           cache.put(request.url, fetchResponse.clone());
+
+          if (!cachedResponse) {
+            // Dispatch event informing of new info cached for the resource
+            this.dispatchEvent(new CustomEvent(request.url));
+          }
         } // Return the original response object, which will be used to fulfill the resource request.
 
 
         return fetchResponse;
       });
 
-      _defineProperty(this, "_unwrappEnvelop", envelop => {
+      _defineProperty(this, "_cacheUnwrappedResources", async (unwrappedResources, fetchResponse, cache) => {
+        // Get Headers and content from response body, get response read-only values,
+        // cache response content with the headers extracted and values found.
+        for (const unwrappedResource of unwrappedResources) {
+          const {
+            ok,
+            redirected,
+            status,
+            statusText
+          } = fetchResponse;
+          const {
+            headers,
+            body,
+            url
+          } = unwrappedResource;
+          const cachedResponse = await cache.match(url);
+          const unWrappedResponse = new Response(body, {
+            headers,
+            status,
+            statusText,
+            url
+          }); // Set response read only values that aren't available in the Response constructor.
+
+          Object.defineProperty(unWrappedResponse, 'url', {
+            value: url
+          });
+          Object.defineProperty(unWrappedResponse, 'ok', {
+            value: ok
+          });
+          Object.defineProperty(unWrappedResponse, 'redirected', {
+            value: redirected
+          }); // Check if an update is needed by looking the headers of the unwrapped resources and if an already cached response is found
+
+          if (cachedResponse) {
+            if (!this._cacheUpToDate(unWrappedResponse, cachedResponse)) {
+              cache.put(url, unWrappedResponse); // Dispatch event informing of new info cached for a unwrapped resource
+
+              this.dispatchEvent(new CustomEvent(url));
+            }
+          } else {
+            cache.put(url, unWrappedResponse);
+          }
+        }
+      });
+
+      _defineProperty(this, "_getUnwrappedEnvelop", envelop => {
         const {
           etag,
           last_modified,
@@ -148,24 +229,26 @@
       _defineProperty(this, "_getUnwrappedResources", async response => {
         const responseLinks = this._parseLinkHeader(response.headers);
 
-        const jsonSchemaURI = responseLinks[this.json_schema_rel_header];
+        const jsonSchemaURI = responseLinks[this.jsonSchemaRelHeader];
         const unwrappedResources = [];
 
         if (jsonSchemaURI && jsonSchemaURI !== response.url) {
-          const schema = await this.get(jsonSchemaURI, true);
+          const schema = await this.get(jsonSchemaURI, {
+            json: true
+          });
           const schemaId = schema.$id;
           const schemaItems = schema.properties.content.properties.items;
 
-          if (schemaId == this.json_schema_envelop_type) {
+          if (schemaId == this.jsonSchemaEnvelopType) {
             // Handle single resource
-            unwrappedResources.push(this._unwrappEnvelop(await response.json()));
+            unwrappedResources.push(this._getUnwrappedEnvelop(await response.json()));
             return unwrappedResources;
-          } else if (schemaItems && schemaItems.$ref == this.json_schema_envelop_type) {
+          } else if (schemaItems && schemaItems.$ref == this.jsonSchemaEnvelopType) {
             // Handle array of resources
             const content = await response.json();
 
             for (const envelop of content) {
-              unwrappedResources.push(this._unwrappEnvelop(envelop));
+              unwrappedResources.push(this._getUnwrappedEnvelop(envelop));
             }
           }
         }
@@ -173,10 +256,33 @@
         return unwrappedResources;
       });
 
+      _defineProperty(this, "_cacheUpToDate", (response, cachedResponse) => {
+        const headers = response.headers;
+        const cacheResponseHeaders = cachedResponse.headers;
+        const lastModifiedHeader = headers.get('Last-Modified');
+        const eTagHeader = headers.get('ETag');
+        const lastModifiedCacheHeader = cacheResponseHeaders.get('Last-Modified');
+        const eTagCacheHeader = cacheResponseHeaders.get('ETag'); // TODO: Check if a better validation is needed
+
+        return eTagCacheHeader != eTagHeader && lastModifiedCacheHeader != lastModifiedHeader;
+      });
+
       _defineProperty(this, "_httpRequest", async (url, requestOptions) => {
         try {
+          // TODO: Add logic to other types of request i.e PUT, DELETE
+          const {
+            method,
+            callback,
+            json
+          } = requestOptions;
+
+          if ((method == this.GET || method == this.POST) && callback) {
+            console.log(callback);
+            this.addEventListener(url, callback);
+          }
+
           const response = await this.cacheRequest(new Request(url, requestOptions));
-          return requestOptions.json ? await this._JSONhandleResponse(response) : response;
+          return json ? await this._JSONhandleResponse(response) : response;
         } catch (err) {
           console.error('Error while catching the request', err);
         }
@@ -218,76 +324,78 @@
         return data;
       });
 
-      _defineProperty(this, "get", async (url, json, options) => {
-        const requestOptions = _objectSpread(_objectSpread({
-          method: 'GET'
-        }, options), {}, {
-          json
-        });
+      _defineProperty(this, "get", async (url, options) => {
+        const requestOptions = _objectSpread({
+          method: this.GET
+        }, options);
 
         return this._httpRequest(url, requestOptions);
       });
 
-      _defineProperty(this, "options", async (url, json, options) => {
-        const requestOptions = _objectSpread(_objectSpread({
-          method: 'OPTIONS'
-        }, options), {}, {
-          json
-        });
+      _defineProperty(this, "options", async (url, options) => {
+        const requestOptions = _objectSpread({
+          method: this.OPTIONS
+        }, options);
 
         return this._httpRequest(url, requestOptions);
       });
 
-      _defineProperty(this, "post", async (url, body, json, options) => {
-        const requestOptions = _objectSpread(_objectSpread({
-          method: 'POST',
+      _defineProperty(this, "post", async (url, body, options) => {
+        const requestOptions = _objectSpread({
+          method: this.POST,
           headers: {
             'Content-Type': 'application/json'
           },
           body: JSON.stringify(body)
-        }, options), {}, {
-          json
-        });
+        }, options);
 
         return this._httpRequest(url, requestOptions);
       });
 
-      _defineProperty(this, "put", async (url, body, json, options) => {
-        const requestOptions = _objectSpread(_objectSpread({
-          method: 'PUT',
+      _defineProperty(this, "put", async (url, body, options) => {
+        const requestOptions = _objectSpread({
+          method: this.PUT,
           headers: {
             'Content-Type': 'application/json'
           },
           body: JSON.stringify(body)
-        }, options), {}, {
-          json
-        });
+        }, options);
 
         return this._httpRequest(url, requestOptions);
       });
 
-      _defineProperty(this, "delete", async (url, json, options) => {
-        const requestOptions = _objectSpread(_objectSpread({
-          method: 'DELETE'
-        }, options), {}, {
-          json
-        });
+      _defineProperty(this, "delete", async (url, options) => {
+        const requestOptions = _objectSpread({
+          method: this.DELETE
+        }, options);
 
         return this._httpRequest(url, requestOptions);
       });
 
-      this.cache_version = cache_version;
-      this.current_cache = current_cache;
-      this.current_caches = {};
-      this.current_caches[current_cache] = `${current_cache}-cache-v${cache_version}`;
-      this.json_schema_rel_header = json_schema_rel_header;
-      this.json_schema_envelop_type = json_schema_envelop_type;
+      this.cacheVersion = cacheVersion;
+      this.currentCache = currentCache;
+      this.currentCaches = {};
+      this.currentCaches[currentCache] = `${currentCache}-cache-v${cacheVersion}`;
+      this.jsonSchemaRelHeader = jsonSchemaRelHeader;
+      this.jsonSchemaEnvelopType = jsonSchemaEnvelopType;
     } // ----- Cache handling
     // Clears unhandled caches
 
 
   } // Export of the functions that should be available for external use.
 
+
+  _defineProperty(CachingClient, "GET", 'GET');
+
+  _defineProperty(CachingClient, "POST", 'POST');
+
+  _defineProperty(CachingClient, "HEAD", 'HEAD');
+
+  _defineProperty(CachingClient, "OPTIONS", 'OPTIONS');
+
+  _defineProperty(CachingClient, "PUT", 'PUT');
+
+  _defineProperty(CachingClient, "DELETE", 'DELETE');
 
   var _default = CachingClient;
   _exports.default = _default;

--- a/cachingClient/demo/index.js
+++ b/cachingClient/demo/index.js
@@ -16,7 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.cachingClient = void 0;
+  _exports.default = void 0;
 
   function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -29,277 +29,266 @@
   // * https://github.com/GoogleChrome/samples/tree/gh-pages/service-worker/read-through-caching
   // * https://gist.github.com/niallo/3109252#gistcomment-2883309
   // ----- Constants and values (probably need to be configurable)
-  const CACHE_VERSION = 1;
-  const CURRENT_CACHES = {
-    'read-through': 'read-through-cache-v' + CACHE_VERSION
-  };
-  const CURRENT_CACHE = 'read-through';
-  const JSON_SCHEMA_REL_HEADER = 'rel=\'describedBy\'';
-  const JSON_SCHEMA_ENVELOP_TYPE = 'https://api.openteams.com/json-schema/Envelope'; // ----- Cache handling
-  // Clears unhandled caches
+  class CachingClient extends EventTarget {
+    constructor(cache_version = 1, current_cache = 'read-through', json_schema_rel_header = 'rel=\'describedBy\'', json_schema_envelop_type = 'https://api.openteams.com/json-schema/Envelope') {
+      super();
 
-  async function clearUnknownCache() {
-    const expectedCacheNames = Object.keys(CURRENT_CACHES).map(function (key) {
-      return CURRENT_CACHES[key];
-    });
-    const cacheNames = await caches.keys();
-    return Promise.all(cacheNames.map(function (cacheName) {
-      if (expectedCacheNames.indexOf(cacheName) === -1) {
-        // If this cache name isn't present in the array of "expected" cache names, then delete it.
-        // console.log('Deleting out of date cache:', cacheName);
-        return caches.delete(cacheName);
-      }
-    }));
-  } // Clear the current cache (CURRENT_CACHE)
+      _defineProperty(this, "clearUnknownCache", async () => {
+        const expectedCacheNames = Object.keys(this.current_caches).map(function (key) {
+          return this.current_caches[key];
+        });
+        const cacheNames = await caches.keys();
+        return Promise.all(cacheNames.map(function (cacheName) {
+          if (expectedCacheNames.indexOf(cacheName) === -1) {
+            // If this cache name isn't present in the array of "expected" cache names, then delete it.
+            // console.log('Deleting out of date cache:', cacheName);
+            return caches.delete(cacheName);
+          }
+        }));
+      });
 
+      _defineProperty(this, "clearCache", async () => {
+        return await caches.delete(this.current_caches[this.current_cache]);
+      });
 
-  async function clearCache() {
-    return await caches.delete(CURRENT_CACHES[CURRENT_CACHE]);
-  } // Retrieve and cache a response from a new request or retrieve response from cache
+      _defineProperty(this, "cacheRequest", async request => {
+        const cache = await caches.open(this.current_caches[this.current_cache]);
+        let cacheResponse = await cache.match(request.url);
 
-
-  async function cacheRequest(request) {
-    const cache = await caches.open(CURRENT_CACHES['read-through']);
-    let cacheResponse = await cache.match(request.url);
-
-    if (cacheResponse) {
-      // If there is an entry in the cache for request.url, then response will be defined
-      // and we can just return it for now.
-      // TODO: Add a way to check if an update to the cache is needed
-      // e.g do a HEAD request to check cache headers for the resource.
-      // console.log(' Found response in cache:', cacheResponse);
-      return cacheResponse;
-    } // Otherwise, if there is no entry in the cache for request.url, response will be
-    // undefined, and we need to fetch() the resource.
-    // console.log(' No response for %s found in cache. ' + 'About to fetch from network...', request.url);
-    // We call .clone() on the request since we might use it in the call to cache.put() later on.
-    // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
-    // (see https://fetch.spec.whatwg.org/#dom-request-clone)
+        if (cacheResponse) {
+          // If there is an entry in the cache for request.url, then response will be defined
+          // and we can just return it for now.
+          // TODO: Add a way to check if an update to the cache is needed
+          // e.g do a HEAD request to check cache headers for the resource.
+          // console.log(' Found response in cache:', cacheResponse);
+          return cacheResponse;
+        } // Otherwise, if there is no entry in the cache for request.url, response will be
+        // undefined, and we need to fetch() the resource.
+        // console.log(' No response for %s found in cache. ' + 'About to fetch from network...', request.url);
+        // We call .clone() on the request since we might use it in the call to cache.put() later on.
+        // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
+        // (see https://fetch.spec.whatwg.org/#dom-request-clone)
 
 
-    const fetchResponse = await fetch(request.clone()); // console.log('  Response for %s from network is: %O', request.url, fetchResponse);
-    // Optional: Add in extra conditions here, e.g. response.type == 'basic' to only cache
-    // responses from the same domain. See https://fetch.spec.whatwg.org/#concept-response-type
+        const fetchResponse = await fetch(request.clone()); // console.log('  Response for %s from network is: %O', request.url, fetchResponse);
+        // Optional: Add in extra conditions here, e.g. response.type == 'basic' to only cache
+        // responses from the same domain. See https://fetch.spec.whatwg.org/#concept-response-type
 
-    if (fetchResponse.status < 400) {
-      // This avoids caching responses that we know are errors (i.e. HTTP status code of 4xx or 5xx).
-      // One limitation is that, for non-CORS requests, we get back a filtered opaque response
-      // (https://fetch.spec.whatwg.org/#concept-filtered-response-opaque) which will always have a
-      // .status of 0, regardless of whether the underlying HTTP call was successful. Since we're
-      // blindly caching those opaque responses, we run the risk of caching a transient error response.
-      //
-      // We need to call .clone() on the response object to save a copy of it to the cache.
-      // (https://fetch.spec.whatwg.org/#dom-request-clone)
-      const unwrappResources = await getUnwrappedResources(fetchResponse.clone());
+        if (fetchResponse.status < 400) {
+          // This avoids caching responses that we know are errors (i.e. HTTP status code of 4xx or 5xx).
+          // One limitation is that, for non-CORS requests, we get back a filtered opaque response
+          // (https://fetch.spec.whatwg.org/#concept-filtered-response-opaque) which will always have a
+          // .status of 0, regardless of whether the underlying HTTP call was successful. Since we're
+          // blindly caching those opaque responses, we run the risk of caching a transient error response.
+          //
+          // We need to call .clone() on the response object to save a copy of it to the cache.
+          // (https://fetch.spec.whatwg.org/#dom-request-clone)
+          const unwrappResources = await this._getUnwrappedResources(fetchResponse.clone());
 
-      if (unwrappResources.length > 0) {
-        // Get Headers and content from response body, get response read-only values,
-        // cache response content with the headers extracted and values found.
-        for (const unwrappResource of unwrappResources) {
-          const {
-            ok,
-            redirected,
-            status,
-            statusText
-          } = fetchResponse;
-          const {
-            headers,
-            body,
-            url
-          } = unwrappResource;
-          const unWrappResponse = new Response(body, {
-            headers,
-            status,
-            statusText,
-            url
-          }); // Set response read only values that aren't available in the Response constructor.
+          if (unwrappResources.length > 0) {
+            // Get Headers and content from response body, get response read-only values,
+            // cache response content with the headers extracted and values found.
+            for (const unwrappResource of unwrappResources) {
+              const {
+                ok,
+                redirected,
+                status,
+                statusText
+              } = fetchResponse;
+              const {
+                headers,
+                body,
+                url
+              } = unwrappResource;
+              const unWrappResponse = new Response(body, {
+                headers,
+                status,
+                statusText,
+                url
+              }); // Set response read only values that aren't available in the Response constructor.
 
-          Object.defineProperty(unWrappResponse, 'url', {
-            value: url
-          });
-          Object.defineProperty(unWrappResponse, 'ok', {
-            value: ok
-          });
-          Object.defineProperty(unWrappResponse, 'redirected', {
-            value: redirected
-          });
-          cache.put(url, unWrappResponse);
+              Object.defineProperty(unWrappResponse, 'url', {
+                value: url
+              });
+              Object.defineProperty(unWrappResponse, 'ok', {
+                value: ok
+              });
+              Object.defineProperty(unWrappResponse, 'redirected', {
+                value: redirected
+              });
+              cache.put(url, unWrappResponse);
+            }
+          }
+
+          cache.put(request.url, fetchResponse.clone());
+        } // Return the original response object, which will be used to fulfill the resource request.
+
+
+        return fetchResponse;
+      });
+
+      _defineProperty(this, "_unwrappEnvelop", envelop => {
+        const {
+          etag,
+          last_modified,
+          url,
+          content
+        } = envelop;
+        const headers = {
+          ETag: etag,
+          'Last-Modified': last_modified
+        };
+        return {
+          headers,
+          body: JSON.stringify(content),
+          url
+        };
+      });
+
+      _defineProperty(this, "_getUnwrappedResources", async response => {
+        const responseLinks = this._parseLinkHeader(response.headers);
+
+        const jsonSchemaURI = responseLinks[this.json_schema_rel_header];
+        const unwrappedResources = [];
+
+        if (jsonSchemaURI && jsonSchemaURI !== response.url) {
+          const schema = await this.get(jsonSchemaURI, true);
+          const schemaId = schema.$id;
+          const schemaItems = schema.properties.content.properties.items;
+
+          if (schemaId == this.json_schema_envelop_type) {
+            // Handle single resource
+            unwrappedResources.push(this._unwrappEnvelop(await response.json()));
+            return unwrappedResources;
+          } else if (schemaItems && schemaItems.$ref == this.json_schema_envelop_type) {
+            // Handle array of resources
+            const content = await response.json();
+
+            for (const envelop of content) {
+              unwrappedResources.push(this._unwrappEnvelop(envelop));
+            }
+          }
         }
-      }
 
-      cache.put(request.url, fetchResponse.clone());
-    } // Return the original response object, which will be used to fulfill the resource request.
-
-
-    return fetchResponse;
-  } // ----- Envelop handling functions
-  // Extract information from an envelop. Get the headers, body and url from the envelop provided.
-
-
-  function unwrappEnvelop(envelop) {
-    const {
-      etag,
-      last_modified,
-      url,
-      content
-    } = envelop;
-    const headers = {
-      ETag: etag,
-      'Last-Modified': last_modified
-    };
-    return {
-      headers,
-      body: JSON.stringify(content),
-      url
-    };
-  } // Detect that a response is an Envelop and retrieve a list of unwrapped envelopes if needed.
-
-
-  async function getUnwrappedResources(response) {
-    const responseLinks = _parseLinkHeader(response.headers);
-
-    const jsonSchemaURI = responseLinks[JSON_SCHEMA_REL_HEADER];
-    const unwrappedResources = [];
-
-    if (jsonSchemaURI && jsonSchemaURI !== response.url) {
-      const schema = await get(jsonSchemaURI, true);
-      const schemaId = schema.$id;
-      const schemaItems = schema.properties.content.properties.items;
-
-      if (schemaId == JSON_SCHEMA_ENVELOP_TYPE) {
-        // Handle single resource
-        unwrappedResources.push(unwrappEnvelop(await response.json()));
         return unwrappedResources;
-      } else if (schemaItems && schemaItems.$ref == JSON_SCHEMA_ENVELOP_TYPE) {
-        // Handle array of resources
-        const content = await response.json();
+      });
 
-        for (const envelop of content) {
-          unwrappedResources.push(unwrappEnvelop(envelop));
+      _defineProperty(this, "_httpRequest", async (url, requestOptions) => {
+        try {
+          const response = await this.cacheRequest(new Request(url, requestOptions));
+          return requestOptions.json ? await this._JSONhandleResponse(response) : response;
+        } catch (err) {
+          console.error('Error while catching the request', err);
         }
-      }
-    }
+      });
 
-    return unwrappedResources;
-  } // ----- Helper functions to cache requests
+      _defineProperty(this, "_parseLinkHeader", headers => {
+        // Taken from: https://gist.github.com/niallo/3109252#gistcomment-2883309
+        const header = headers.get('Link');
 
-
-  async function _httpRequest(url, requestOptions) {
-    try {
-      const response = await cacheRequest(new Request(url, requestOptions));
-      return requestOptions.json ? await JSONhandleResponse(response) : response;
-    } catch (err) {
-      console.error('Error while catching the request', err);
-    }
-  } // Parse link headers and retrieve an object {rel0: url0, rel1: url1}
+        if (!header || header.length === 0) {
+          return {};
+        } // Split parts by comma and parse each part into a named link
 
 
-  function _parseLinkHeader(headers) {
-    // Taken from: https://gist.github.com/niallo/3109252#gistcomment-2883309
-    const header = headers.get('Link');
+        const found = header.split(/(?!\B"[^"]*),(?![^"]*"\B)/).reduce((links, part) => {
+          const section = part.split(/(?!\B"[^"]*);(?![^"]*"\B)/);
 
-    if (!header || header.length === 0) {
-      return {};
-    } // Split parts by comma and parse each part into a named link
+          if (section.length < 2) {
+            throw new Error("Section could not be split on ';'");
+          }
+
+          const url = section[0].replace(/<(.*)>/, '$1').trim();
+          const name = section[1].replace(/rel="(.*)"/, '$1').trim();
+          links[name] = url;
+          return links;
+        }, {});
+        return found;
+      });
+
+      _defineProperty(this, "_JSONhandleResponse", async response => {
+        const text = await response.text();
+        const data = text && JSON.parse(text);
+
+        if (!response.ok) {
+          const error = data && data.message || response.statusText;
+          return Promise.reject(error);
+        }
+
+        return data;
+      });
+
+      _defineProperty(this, "get", async (url, json, options) => {
+        const requestOptions = _objectSpread(_objectSpread({
+          method: 'GET'
+        }, options), {}, {
+          json
+        });
+
+        return this._httpRequest(url, requestOptions);
+      });
+
+      _defineProperty(this, "options", async (url, json, options) => {
+        const requestOptions = _objectSpread(_objectSpread({
+          method: 'OPTIONS'
+        }, options), {}, {
+          json
+        });
+
+        return this._httpRequest(url, requestOptions);
+      });
+
+      _defineProperty(this, "post", async (url, body, json, options) => {
+        const requestOptions = _objectSpread(_objectSpread({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(body)
+        }, options), {}, {
+          json
+        });
+
+        return this._httpRequest(url, requestOptions);
+      });
+
+      _defineProperty(this, "put", async (url, body, json, options) => {
+        const requestOptions = _objectSpread(_objectSpread({
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(body)
+        }, options), {}, {
+          json
+        });
+
+        return this._httpRequest(url, requestOptions);
+      });
+
+      _defineProperty(this, "delete", async (url, json, options) => {
+        const requestOptions = _objectSpread(_objectSpread({
+          method: 'DELETE'
+        }, options), {}, {
+          json
+        });
+
+        return this._httpRequest(url, requestOptions);
+      });
+
+      this.cache_version = cache_version;
+      this.current_cache = current_cache;
+      this.current_caches = {};
+      this.current_caches[current_cache] = `${current_cache}-cache-v${cache_version}`;
+      this.json_schema_rel_header = json_schema_rel_header;
+      this.json_schema_envelop_type = json_schema_envelop_type;
+    } // ----- Cache handling
+    // Clears unhandled caches
 
 
-    const found = header.split(/(?!\B"[^"]*),(?![^"]*"\B)/).reduce((links, part) => {
-      const section = part.split(/(?!\B"[^"]*);(?![^"]*"\B)/);
-
-      if (section.length < 2) {
-        throw new Error("Section could not be split on ';'");
-      }
-
-      const url = section[0].replace(/<(.*)>/, '$1').trim();
-      const name = section[1].replace(/rel="(.*)"/, '$1').trim();
-      links[name] = url;
-      return links;
-    }, {});
-    return found;
-  } // ----- Requests available (GET, OPTIONS, POST, PUT, DELETE)
-
-
-  async function get(url, json, options) {
-    const requestOptions = _objectSpread(_objectSpread({
-      method: 'GET'
-    }, options), {}, {
-      json
-    });
-
-    return _httpRequest(url, requestOptions);
-  }
-
-  async function options(url, json, options) {
-    const requestOptions = _objectSpread(_objectSpread({
-      method: 'OPTIONS'
-    }, options), {}, {
-      json
-    });
-
-    return _httpRequest(url, requestOptions);
-  }
-
-  async function post(url, body, json, options) {
-    const requestOptions = _objectSpread(_objectSpread({
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(body)
-    }, options), {}, {
-      json
-    });
-
-    return _httpRequest(url, requestOptions);
-  }
-
-  async function put(url, body, json, options) {
-    const requestOptions = _objectSpread(_objectSpread({
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(body)
-    }, options), {}, {
-      json
-    });
-
-    return _httpRequest(url, requestOptions);
-  }
-
-  async function _delete(url, json, options) {
-    // Prefixed with underscored because delete is a reserved word in javascript
-    const requestOptions = _objectSpread(_objectSpread({
-      method: 'DELETE'
-    }, options), {}, {
-      json
-    });
-
-    return _httpRequest(url, requestOptions);
-  } // Helper function to parse a response as JSON (Probably not needed in the future and could be replaced with Response.json())
-
-
-  async function JSONhandleResponse(response) {
-    const text = await response.text();
-    const data = text && JSON.parse(text);
-
-    if (!response.ok) {
-      const error = data && data.message || response.statusText;
-      return Promise.reject(error);
-    }
-
-    return data;
   } // Export of the functions that should be available for external use.
 
 
-  const cachingClient = {
-    clearUnknownCache,
-    clearCache,
-    get,
-    options,
-    post,
-    put,
-    delete: _delete
-  };
-  _exports.cachingClient = cachingClient;
+  var _default = CachingClient;
+  _exports.default = _default;
 });

--- a/cachingClient/lib/index.js
+++ b/cachingClient/lib/index.js
@@ -28,14 +28,70 @@
   // * https://jasonwatmore.com/post/2020/04/18/fetch-a-lightweight-fetch-wrapper-to-simplify-http-requests
   // * https://github.com/GoogleChrome/samples/tree/gh-pages/service-worker/read-through-caching
   // * https://gist.github.com/niallo/3109252#gistcomment-2883309
-  // ----- Constants and values (probably need to be configurable)
-  class CachingClient extends EventTarget {
-    constructor(cache_version = 1, current_cache = 'read-through', json_schema_rel_header = 'rel=\'describedBy\'', json_schema_envelop_type = 'https://api.openteams.com/json-schema/Envelope') {
+  // * https://stackoverflow.com/a/58209729
+  // Class definitions (CachingClient and EventDispatcher)
+  // Needed for compatibility with Safari and Explorer since EventTarget there doesn't support the constructor.
+  // Taken from: https://stackoverflow.com/a/58209729
+  class EventDispatcher {
+    constructor() {
+      this._listeners = [];
+    }
+
+    hasEventListener(type, listener) {
+      return this._listeners.some(item => item.type === type && item.listener === listener);
+    }
+
+    addEventListener(type, listener) {
+      if (!this.hasEventListener(type, listener)) {
+        this._listeners.push({
+          type,
+          listener,
+          options: {
+            once: false
+          }
+        });
+      }
+
+      return this;
+    }
+
+    removeEventListener(type, listener) {
+      let index = this._listeners.findIndex(item => item.type === type && item.listener === listener);
+
+      if (index >= 0) this._listeners.splice(index, 1);
+      return this;
+    }
+
+    removeEventListeners() {
+      this._listeners = [];
+      return this;
+    }
+
+    dispatchEvent(evt) {
+      this._listeners.filter(item => item.type === evt.type).forEach(item => {
+        const {
+          type,
+          listener,
+          options: {
+            once
+          }
+        } = item;
+        listener.call(this, evt);
+        if (once === true) this.removeEventListener(type, listener);
+      });
+
+      return this;
+    }
+
+  }
+
+  class CachingClient extends EventDispatcher {
+    constructor(cacheVersion = 1, currentCache = 'read-through', jsonSchemaRelHeader = 'rel=\'describedBy\'', jsonSchemaEnvelopType = 'https://api.openteams.com/json-schema/Envelope') {
       super();
 
       _defineProperty(this, "clearUnknownCache", async () => {
-        const expectedCacheNames = Object.keys(this.current_caches).map(function (key) {
-          return this.current_caches[key];
+        const expectedCacheNames = Object.keys(this.currentCaches).map(function (key) {
+          return this.currentCaches[key];
         });
         const cacheNames = await caches.keys();
         return Promise.all(cacheNames.map(function (cacheName) {
@@ -48,23 +104,29 @@
       });
 
       _defineProperty(this, "clearCache", async () => {
-        return await caches.delete(this.current_caches[this.current_cache]);
+        return await caches.delete(this.currentCaches[this.currentCache]);
       });
 
       _defineProperty(this, "cacheRequest", async request => {
-        const cache = await caches.open(this.current_caches[this.current_cache]);
-        let cacheResponse = await cache.match(request.url);
+        const cache = await caches.open(this.currentCaches[this.currentCache]);
+        const cachedResponse = await cache.match(request.url);
 
-        if (cacheResponse) {
+        if (cachedResponse) {
           // If there is an entry in the cache for request.url, then response will be defined
           // and we can just return it for now.
-          // TODO: Add a way to check if an update to the cache is needed
           // e.g do a HEAD request to check cache headers for the resource.
-          // console.log(' Found response in cache:', cacheResponse);
-          return cacheResponse;
-        } // Otherwise, if there is no entry in the cache for request.url, response will be
-        // undefined, and we need to fetch() the resource.
-        // console.log(' No response for %s found in cache. ' + 'About to fetch from network...', request.url);
+          // console.log(' Found response in cache:', cachedResponse);
+          // TODO: Add a way to check if an update to the cache is needed
+          const headResponse = await fetch(request.url, {
+            method: this.HEAD
+          });
+
+          if (this._cacheUpToDate(headResponse, cachedResponse)) {
+            return cachedResponse;
+          }
+        } // Otherwise, if there is no entry in the cache for request.url or it needs to be updated, response will be
+        // undefined or old, and we need to fetch() the resource.
+        // console.log(' No response for %s found in cache or response stored is old. ' + 'About to fetch from network...', request.url);
         // We call .clone() on the request since we might use it in the call to cache.put() later on.
         // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
         // (see https://fetch.spec.whatwg.org/#dom-request-clone)
@@ -83,51 +145,70 @@
           //
           // We need to call .clone() on the response object to save a copy of it to the cache.
           // (https://fetch.spec.whatwg.org/#dom-request-clone)
-          const unwrappResources = await this._getUnwrappedResources(fetchResponse.clone());
+          const unwrappedResources = await this._getUnwrappedResources(fetchResponse.clone());
 
-          if (unwrappResources.length > 0) {
-            // Get Headers and content from response body, get response read-only values,
-            // cache response content with the headers extracted and values found.
-            for (const unwrappResource of unwrappResources) {
-              const {
-                ok,
-                redirected,
-                status,
-                statusText
-              } = fetchResponse;
-              const {
-                headers,
-                body,
-                url
-              } = unwrappResource;
-              const unWrappResponse = new Response(body, {
-                headers,
-                status,
-                statusText,
-                url
-              }); // Set response read only values that aren't available in the Response constructor.
-
-              Object.defineProperty(unWrappResponse, 'url', {
-                value: url
-              });
-              Object.defineProperty(unWrappResponse, 'ok', {
-                value: ok
-              });
-              Object.defineProperty(unWrappResponse, 'redirected', {
-                value: redirected
-              });
-              cache.put(url, unWrappResponse);
-            }
+          if (unwrappedResources.length > 0) {
+            this._cacheUnwrappedResources(unwrappedResources, fetchResponse, cache);
           }
 
           cache.put(request.url, fetchResponse.clone());
+
+          if (!cachedResponse) {
+            // Dispatch event informing of new info cached for the resource
+            this.dispatchEvent(new CustomEvent(request.url));
+          }
         } // Return the original response object, which will be used to fulfill the resource request.
 
 
         return fetchResponse;
       });
 
-      _defineProperty(this, "_unwrappEnvelop", envelop => {
+      _defineProperty(this, "_cacheUnwrappedResources", async (unwrappedResources, fetchResponse, cache) => {
+        // Get Headers and content from response body, get response read-only values,
+        // cache response content with the headers extracted and values found.
+        for (const unwrappedResource of unwrappedResources) {
+          const {
+            ok,
+            redirected,
+            status,
+            statusText
+          } = fetchResponse;
+          const {
+            headers,
+            body,
+            url
+          } = unwrappedResource;
+          const cachedResponse = await cache.match(url);
+          const unWrappedResponse = new Response(body, {
+            headers,
+            status,
+            statusText,
+            url
+          }); // Set response read only values that aren't available in the Response constructor.
+
+          Object.defineProperty(unWrappedResponse, 'url', {
+            value: url
+          });
+          Object.defineProperty(unWrappedResponse, 'ok', {
+            value: ok
+          });
+          Object.defineProperty(unWrappedResponse, 'redirected', {
+            value: redirected
+          }); // Check if an update is needed by looking the headers of the unwrapped resources and if an already cached response is found
+
+          if (cachedResponse) {
+            if (!this._cacheUpToDate(unWrappedResponse, cachedResponse)) {
+              cache.put(url, unWrappedResponse); // Dispatch event informing of new info cached for a unwrapped resource
+
+              this.dispatchEvent(new CustomEvent(url));
+            }
+          } else {
+            cache.put(url, unWrappedResponse);
+          }
+        }
+      });
+
+      _defineProperty(this, "_getUnwrappedEnvelop", envelop => {
         const {
           etag,
           last_modified,
@@ -148,24 +229,26 @@
       _defineProperty(this, "_getUnwrappedResources", async response => {
         const responseLinks = this._parseLinkHeader(response.headers);
 
-        const jsonSchemaURI = responseLinks[this.json_schema_rel_header];
+        const jsonSchemaURI = responseLinks[this.jsonSchemaRelHeader];
         const unwrappedResources = [];
 
         if (jsonSchemaURI && jsonSchemaURI !== response.url) {
-          const schema = await this.get(jsonSchemaURI, true);
+          const schema = await this.get(jsonSchemaURI, {
+            json: true
+          });
           const schemaId = schema.$id;
           const schemaItems = schema.properties.content.properties.items;
 
-          if (schemaId == this.json_schema_envelop_type) {
+          if (schemaId == this.jsonSchemaEnvelopType) {
             // Handle single resource
-            unwrappedResources.push(this._unwrappEnvelop(await response.json()));
+            unwrappedResources.push(this._getUnwrappedEnvelop(await response.json()));
             return unwrappedResources;
-          } else if (schemaItems && schemaItems.$ref == this.json_schema_envelop_type) {
+          } else if (schemaItems && schemaItems.$ref == this.jsonSchemaEnvelopType) {
             // Handle array of resources
             const content = await response.json();
 
             for (const envelop of content) {
-              unwrappedResources.push(this._unwrappEnvelop(envelop));
+              unwrappedResources.push(this._getUnwrappedEnvelop(envelop));
             }
           }
         }
@@ -173,10 +256,33 @@
         return unwrappedResources;
       });
 
+      _defineProperty(this, "_cacheUpToDate", (response, cachedResponse) => {
+        const headers = response.headers;
+        const cacheResponseHeaders = cachedResponse.headers;
+        const lastModifiedHeader = headers.get('Last-Modified');
+        const eTagHeader = headers.get('ETag');
+        const lastModifiedCacheHeader = cacheResponseHeaders.get('Last-Modified');
+        const eTagCacheHeader = cacheResponseHeaders.get('ETag'); // TODO: Check if a better validation is needed
+
+        return eTagCacheHeader != eTagHeader && lastModifiedCacheHeader != lastModifiedHeader;
+      });
+
       _defineProperty(this, "_httpRequest", async (url, requestOptions) => {
         try {
+          // TODO: Add logic to other types of request i.e PUT, DELETE
+          const {
+            method,
+            callback,
+            json
+          } = requestOptions;
+
+          if ((method == this.GET || method == this.POST) && callback) {
+            console.log(callback);
+            this.addEventListener(url, callback);
+          }
+
           const response = await this.cacheRequest(new Request(url, requestOptions));
-          return requestOptions.json ? await this._JSONhandleResponse(response) : response;
+          return json ? await this._JSONhandleResponse(response) : response;
         } catch (err) {
           console.error('Error while catching the request', err);
         }
@@ -218,76 +324,78 @@
         return data;
       });
 
-      _defineProperty(this, "get", async (url, json, options) => {
-        const requestOptions = _objectSpread(_objectSpread({
-          method: 'GET'
-        }, options), {}, {
-          json
-        });
+      _defineProperty(this, "get", async (url, options) => {
+        const requestOptions = _objectSpread({
+          method: this.GET
+        }, options);
 
         return this._httpRequest(url, requestOptions);
       });
 
-      _defineProperty(this, "options", async (url, json, options) => {
-        const requestOptions = _objectSpread(_objectSpread({
-          method: 'OPTIONS'
-        }, options), {}, {
-          json
-        });
+      _defineProperty(this, "options", async (url, options) => {
+        const requestOptions = _objectSpread({
+          method: this.OPTIONS
+        }, options);
 
         return this._httpRequest(url, requestOptions);
       });
 
-      _defineProperty(this, "post", async (url, body, json, options) => {
-        const requestOptions = _objectSpread(_objectSpread({
-          method: 'POST',
+      _defineProperty(this, "post", async (url, body, options) => {
+        const requestOptions = _objectSpread({
+          method: this.POST,
           headers: {
             'Content-Type': 'application/json'
           },
           body: JSON.stringify(body)
-        }, options), {}, {
-          json
-        });
+        }, options);
 
         return this._httpRequest(url, requestOptions);
       });
 
-      _defineProperty(this, "put", async (url, body, json, options) => {
-        const requestOptions = _objectSpread(_objectSpread({
-          method: 'PUT',
+      _defineProperty(this, "put", async (url, body, options) => {
+        const requestOptions = _objectSpread({
+          method: this.PUT,
           headers: {
             'Content-Type': 'application/json'
           },
           body: JSON.stringify(body)
-        }, options), {}, {
-          json
-        });
+        }, options);
 
         return this._httpRequest(url, requestOptions);
       });
 
-      _defineProperty(this, "delete", async (url, json, options) => {
-        const requestOptions = _objectSpread(_objectSpread({
-          method: 'DELETE'
-        }, options), {}, {
-          json
-        });
+      _defineProperty(this, "delete", async (url, options) => {
+        const requestOptions = _objectSpread({
+          method: this.DELETE
+        }, options);
 
         return this._httpRequest(url, requestOptions);
       });
 
-      this.cache_version = cache_version;
-      this.current_cache = current_cache;
-      this.current_caches = {};
-      this.current_caches[current_cache] = `${current_cache}-cache-v${cache_version}`;
-      this.json_schema_rel_header = json_schema_rel_header;
-      this.json_schema_envelop_type = json_schema_envelop_type;
+      this.cacheVersion = cacheVersion;
+      this.currentCache = currentCache;
+      this.currentCaches = {};
+      this.currentCaches[currentCache] = `${currentCache}-cache-v${cacheVersion}`;
+      this.jsonSchemaRelHeader = jsonSchemaRelHeader;
+      this.jsonSchemaEnvelopType = jsonSchemaEnvelopType;
     } // ----- Cache handling
     // Clears unhandled caches
 
 
   } // Export of the functions that should be available for external use.
 
+
+  _defineProperty(CachingClient, "GET", 'GET');
+
+  _defineProperty(CachingClient, "POST", 'POST');
+
+  _defineProperty(CachingClient, "HEAD", 'HEAD');
+
+  _defineProperty(CachingClient, "OPTIONS", 'OPTIONS');
+
+  _defineProperty(CachingClient, "PUT", 'PUT');
+
+  _defineProperty(CachingClient, "DELETE", 'DELETE');
 
   var _default = CachingClient;
   _exports.default = _default;

--- a/cachingClient/lib/index.js
+++ b/cachingClient/lib/index.js
@@ -16,7 +16,7 @@
   Object.defineProperty(_exports, "__esModule", {
     value: true
   });
-  _exports.cachingClient = void 0;
+  _exports.default = void 0;
 
   function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); if (enumerableOnly) symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; }); keys.push.apply(keys, symbols); } return keys; }
 
@@ -29,277 +29,266 @@
   // * https://github.com/GoogleChrome/samples/tree/gh-pages/service-worker/read-through-caching
   // * https://gist.github.com/niallo/3109252#gistcomment-2883309
   // ----- Constants and values (probably need to be configurable)
-  const CACHE_VERSION = 1;
-  const CURRENT_CACHES = {
-    'read-through': 'read-through-cache-v' + CACHE_VERSION
-  };
-  const CURRENT_CACHE = 'read-through';
-  const JSON_SCHEMA_REL_HEADER = 'rel=\'describedBy\'';
-  const JSON_SCHEMA_ENVELOP_TYPE = 'https://api.openteams.com/json-schema/Envelope'; // ----- Cache handling
-  // Clears unhandled caches
+  class CachingClient extends EventTarget {
+    constructor(cache_version = 1, current_cache = 'read-through', json_schema_rel_header = 'rel=\'describedBy\'', json_schema_envelop_type = 'https://api.openteams.com/json-schema/Envelope') {
+      super();
 
-  async function clearUnknownCache() {
-    const expectedCacheNames = Object.keys(CURRENT_CACHES).map(function (key) {
-      return CURRENT_CACHES[key];
-    });
-    const cacheNames = await caches.keys();
-    return Promise.all(cacheNames.map(function (cacheName) {
-      if (expectedCacheNames.indexOf(cacheName) === -1) {
-        // If this cache name isn't present in the array of "expected" cache names, then delete it.
-        // console.log('Deleting out of date cache:', cacheName);
-        return caches.delete(cacheName);
-      }
-    }));
-  } // Clear the current cache (CURRENT_CACHE)
+      _defineProperty(this, "clearUnknownCache", async () => {
+        const expectedCacheNames = Object.keys(this.current_caches).map(function (key) {
+          return this.current_caches[key];
+        });
+        const cacheNames = await caches.keys();
+        return Promise.all(cacheNames.map(function (cacheName) {
+          if (expectedCacheNames.indexOf(cacheName) === -1) {
+            // If this cache name isn't present in the array of "expected" cache names, then delete it.
+            // console.log('Deleting out of date cache:', cacheName);
+            return caches.delete(cacheName);
+          }
+        }));
+      });
 
+      _defineProperty(this, "clearCache", async () => {
+        return await caches.delete(this.current_caches[this.current_cache]);
+      });
 
-  async function clearCache() {
-    return await caches.delete(CURRENT_CACHES[CURRENT_CACHE]);
-  } // Retrieve and cache a response from a new request or retrieve response from cache
+      _defineProperty(this, "cacheRequest", async request => {
+        const cache = await caches.open(this.current_caches[this.current_cache]);
+        let cacheResponse = await cache.match(request.url);
 
-
-  async function cacheRequest(request) {
-    const cache = await caches.open(CURRENT_CACHES['read-through']);
-    let cacheResponse = await cache.match(request.url);
-
-    if (cacheResponse) {
-      // If there is an entry in the cache for request.url, then response will be defined
-      // and we can just return it for now.
-      // TODO: Add a way to check if an update to the cache is needed
-      // e.g do a HEAD request to check cache headers for the resource.
-      // console.log(' Found response in cache:', cacheResponse);
-      return cacheResponse;
-    } // Otherwise, if there is no entry in the cache for request.url, response will be
-    // undefined, and we need to fetch() the resource.
-    // console.log(' No response for %s found in cache. ' + 'About to fetch from network...', request.url);
-    // We call .clone() on the request since we might use it in the call to cache.put() later on.
-    // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
-    // (see https://fetch.spec.whatwg.org/#dom-request-clone)
+        if (cacheResponse) {
+          // If there is an entry in the cache for request.url, then response will be defined
+          // and we can just return it for now.
+          // TODO: Add a way to check if an update to the cache is needed
+          // e.g do a HEAD request to check cache headers for the resource.
+          // console.log(' Found response in cache:', cacheResponse);
+          return cacheResponse;
+        } // Otherwise, if there is no entry in the cache for request.url, response will be
+        // undefined, and we need to fetch() the resource.
+        // console.log(' No response for %s found in cache. ' + 'About to fetch from network...', request.url);
+        // We call .clone() on the request since we might use it in the call to cache.put() later on.
+        // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
+        // (see https://fetch.spec.whatwg.org/#dom-request-clone)
 
 
-    const fetchResponse = await fetch(request.clone()); // console.log('  Response for %s from network is: %O', request.url, fetchResponse);
-    // Optional: Add in extra conditions here, e.g. response.type == 'basic' to only cache
-    // responses from the same domain. See https://fetch.spec.whatwg.org/#concept-response-type
+        const fetchResponse = await fetch(request.clone()); // console.log('  Response for %s from network is: %O', request.url, fetchResponse);
+        // Optional: Add in extra conditions here, e.g. response.type == 'basic' to only cache
+        // responses from the same domain. See https://fetch.spec.whatwg.org/#concept-response-type
 
-    if (fetchResponse.status < 400) {
-      // This avoids caching responses that we know are errors (i.e. HTTP status code of 4xx or 5xx).
-      // One limitation is that, for non-CORS requests, we get back a filtered opaque response
-      // (https://fetch.spec.whatwg.org/#concept-filtered-response-opaque) which will always have a
-      // .status of 0, regardless of whether the underlying HTTP call was successful. Since we're
-      // blindly caching those opaque responses, we run the risk of caching a transient error response.
-      //
-      // We need to call .clone() on the response object to save a copy of it to the cache.
-      // (https://fetch.spec.whatwg.org/#dom-request-clone)
-      const unwrappResources = await getUnwrappedResources(fetchResponse.clone());
+        if (fetchResponse.status < 400) {
+          // This avoids caching responses that we know are errors (i.e. HTTP status code of 4xx or 5xx).
+          // One limitation is that, for non-CORS requests, we get back a filtered opaque response
+          // (https://fetch.spec.whatwg.org/#concept-filtered-response-opaque) which will always have a
+          // .status of 0, regardless of whether the underlying HTTP call was successful. Since we're
+          // blindly caching those opaque responses, we run the risk of caching a transient error response.
+          //
+          // We need to call .clone() on the response object to save a copy of it to the cache.
+          // (https://fetch.spec.whatwg.org/#dom-request-clone)
+          const unwrappResources = await this._getUnwrappedResources(fetchResponse.clone());
 
-      if (unwrappResources.length > 0) {
-        // Get Headers and content from response body, get response read-only values,
-        // cache response content with the headers extracted and values found.
-        for (const unwrappResource of unwrappResources) {
-          const {
-            ok,
-            redirected,
-            status,
-            statusText
-          } = fetchResponse;
-          const {
-            headers,
-            body,
-            url
-          } = unwrappResource;
-          const unWrappResponse = new Response(body, {
-            headers,
-            status,
-            statusText,
-            url
-          }); // Set response read only values that aren't available in the Response constructor.
+          if (unwrappResources.length > 0) {
+            // Get Headers and content from response body, get response read-only values,
+            // cache response content with the headers extracted and values found.
+            for (const unwrappResource of unwrappResources) {
+              const {
+                ok,
+                redirected,
+                status,
+                statusText
+              } = fetchResponse;
+              const {
+                headers,
+                body,
+                url
+              } = unwrappResource;
+              const unWrappResponse = new Response(body, {
+                headers,
+                status,
+                statusText,
+                url
+              }); // Set response read only values that aren't available in the Response constructor.
 
-          Object.defineProperty(unWrappResponse, 'url', {
-            value: url
-          });
-          Object.defineProperty(unWrappResponse, 'ok', {
-            value: ok
-          });
-          Object.defineProperty(unWrappResponse, 'redirected', {
-            value: redirected
-          });
-          cache.put(url, unWrappResponse);
+              Object.defineProperty(unWrappResponse, 'url', {
+                value: url
+              });
+              Object.defineProperty(unWrappResponse, 'ok', {
+                value: ok
+              });
+              Object.defineProperty(unWrappResponse, 'redirected', {
+                value: redirected
+              });
+              cache.put(url, unWrappResponse);
+            }
+          }
+
+          cache.put(request.url, fetchResponse.clone());
+        } // Return the original response object, which will be used to fulfill the resource request.
+
+
+        return fetchResponse;
+      });
+
+      _defineProperty(this, "_unwrappEnvelop", envelop => {
+        const {
+          etag,
+          last_modified,
+          url,
+          content
+        } = envelop;
+        const headers = {
+          ETag: etag,
+          'Last-Modified': last_modified
+        };
+        return {
+          headers,
+          body: JSON.stringify(content),
+          url
+        };
+      });
+
+      _defineProperty(this, "_getUnwrappedResources", async response => {
+        const responseLinks = this._parseLinkHeader(response.headers);
+
+        const jsonSchemaURI = responseLinks[this.json_schema_rel_header];
+        const unwrappedResources = [];
+
+        if (jsonSchemaURI && jsonSchemaURI !== response.url) {
+          const schema = await this.get(jsonSchemaURI, true);
+          const schemaId = schema.$id;
+          const schemaItems = schema.properties.content.properties.items;
+
+          if (schemaId == this.json_schema_envelop_type) {
+            // Handle single resource
+            unwrappedResources.push(this._unwrappEnvelop(await response.json()));
+            return unwrappedResources;
+          } else if (schemaItems && schemaItems.$ref == this.json_schema_envelop_type) {
+            // Handle array of resources
+            const content = await response.json();
+
+            for (const envelop of content) {
+              unwrappedResources.push(this._unwrappEnvelop(envelop));
+            }
+          }
         }
-      }
 
-      cache.put(request.url, fetchResponse.clone());
-    } // Return the original response object, which will be used to fulfill the resource request.
-
-
-    return fetchResponse;
-  } // ----- Envelop handling functions
-  // Extract information from an envelop. Get the headers, body and url from the envelop provided.
-
-
-  function unwrappEnvelop(envelop) {
-    const {
-      etag,
-      last_modified,
-      url,
-      content
-    } = envelop;
-    const headers = {
-      ETag: etag,
-      'Last-Modified': last_modified
-    };
-    return {
-      headers,
-      body: JSON.stringify(content),
-      url
-    };
-  } // Detect that a response is an Envelop and retrieve a list of unwrapped envelopes if needed.
-
-
-  async function getUnwrappedResources(response) {
-    const responseLinks = _parseLinkHeader(response.headers);
-
-    const jsonSchemaURI = responseLinks[JSON_SCHEMA_REL_HEADER];
-    const unwrappedResources = [];
-
-    if (jsonSchemaURI && jsonSchemaURI !== response.url) {
-      const schema = await get(jsonSchemaURI, true);
-      const schemaId = schema.$id;
-      const schemaItems = schema.properties.content.properties.items;
-
-      if (schemaId == JSON_SCHEMA_ENVELOP_TYPE) {
-        // Handle single resource
-        unwrappedResources.push(unwrappEnvelop(await response.json()));
         return unwrappedResources;
-      } else if (schemaItems && schemaItems.$ref == JSON_SCHEMA_ENVELOP_TYPE) {
-        // Handle array of resources
-        const content = await response.json();
+      });
 
-        for (const envelop of content) {
-          unwrappedResources.push(unwrappEnvelop(envelop));
+      _defineProperty(this, "_httpRequest", async (url, requestOptions) => {
+        try {
+          const response = await this.cacheRequest(new Request(url, requestOptions));
+          return requestOptions.json ? await this._JSONhandleResponse(response) : response;
+        } catch (err) {
+          console.error('Error while catching the request', err);
         }
-      }
-    }
+      });
 
-    return unwrappedResources;
-  } // ----- Helper functions to cache requests
+      _defineProperty(this, "_parseLinkHeader", headers => {
+        // Taken from: https://gist.github.com/niallo/3109252#gistcomment-2883309
+        const header = headers.get('Link');
 
-
-  async function _httpRequest(url, requestOptions) {
-    try {
-      const response = await cacheRequest(new Request(url, requestOptions));
-      return requestOptions.json ? await JSONhandleResponse(response) : response;
-    } catch (err) {
-      console.error('Error while catching the request', err);
-    }
-  } // Parse link headers and retrieve an object {rel0: url0, rel1: url1}
+        if (!header || header.length === 0) {
+          return {};
+        } // Split parts by comma and parse each part into a named link
 
 
-  function _parseLinkHeader(headers) {
-    // Taken from: https://gist.github.com/niallo/3109252#gistcomment-2883309
-    const header = headers.get('Link');
+        const found = header.split(/(?!\B"[^"]*),(?![^"]*"\B)/).reduce((links, part) => {
+          const section = part.split(/(?!\B"[^"]*);(?![^"]*"\B)/);
 
-    if (!header || header.length === 0) {
-      return {};
-    } // Split parts by comma and parse each part into a named link
+          if (section.length < 2) {
+            throw new Error("Section could not be split on ';'");
+          }
+
+          const url = section[0].replace(/<(.*)>/, '$1').trim();
+          const name = section[1].replace(/rel="(.*)"/, '$1').trim();
+          links[name] = url;
+          return links;
+        }, {});
+        return found;
+      });
+
+      _defineProperty(this, "_JSONhandleResponse", async response => {
+        const text = await response.text();
+        const data = text && JSON.parse(text);
+
+        if (!response.ok) {
+          const error = data && data.message || response.statusText;
+          return Promise.reject(error);
+        }
+
+        return data;
+      });
+
+      _defineProperty(this, "get", async (url, json, options) => {
+        const requestOptions = _objectSpread(_objectSpread({
+          method: 'GET'
+        }, options), {}, {
+          json
+        });
+
+        return this._httpRequest(url, requestOptions);
+      });
+
+      _defineProperty(this, "options", async (url, json, options) => {
+        const requestOptions = _objectSpread(_objectSpread({
+          method: 'OPTIONS'
+        }, options), {}, {
+          json
+        });
+
+        return this._httpRequest(url, requestOptions);
+      });
+
+      _defineProperty(this, "post", async (url, body, json, options) => {
+        const requestOptions = _objectSpread(_objectSpread({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(body)
+        }, options), {}, {
+          json
+        });
+
+        return this._httpRequest(url, requestOptions);
+      });
+
+      _defineProperty(this, "put", async (url, body, json, options) => {
+        const requestOptions = _objectSpread(_objectSpread({
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(body)
+        }, options), {}, {
+          json
+        });
+
+        return this._httpRequest(url, requestOptions);
+      });
+
+      _defineProperty(this, "delete", async (url, json, options) => {
+        const requestOptions = _objectSpread(_objectSpread({
+          method: 'DELETE'
+        }, options), {}, {
+          json
+        });
+
+        return this._httpRequest(url, requestOptions);
+      });
+
+      this.cache_version = cache_version;
+      this.current_cache = current_cache;
+      this.current_caches = {};
+      this.current_caches[current_cache] = `${current_cache}-cache-v${cache_version}`;
+      this.json_schema_rel_header = json_schema_rel_header;
+      this.json_schema_envelop_type = json_schema_envelop_type;
+    } // ----- Cache handling
+    // Clears unhandled caches
 
 
-    const found = header.split(/(?!\B"[^"]*),(?![^"]*"\B)/).reduce((links, part) => {
-      const section = part.split(/(?!\B"[^"]*);(?![^"]*"\B)/);
-
-      if (section.length < 2) {
-        throw new Error("Section could not be split on ';'");
-      }
-
-      const url = section[0].replace(/<(.*)>/, '$1').trim();
-      const name = section[1].replace(/rel="(.*)"/, '$1').trim();
-      links[name] = url;
-      return links;
-    }, {});
-    return found;
-  } // ----- Requests available (GET, OPTIONS, POST, PUT, DELETE)
-
-
-  async function get(url, json, options) {
-    const requestOptions = _objectSpread(_objectSpread({
-      method: 'GET'
-    }, options), {}, {
-      json
-    });
-
-    return _httpRequest(url, requestOptions);
-  }
-
-  async function options(url, json, options) {
-    const requestOptions = _objectSpread(_objectSpread({
-      method: 'OPTIONS'
-    }, options), {}, {
-      json
-    });
-
-    return _httpRequest(url, requestOptions);
-  }
-
-  async function post(url, body, json, options) {
-    const requestOptions = _objectSpread(_objectSpread({
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(body)
-    }, options), {}, {
-      json
-    });
-
-    return _httpRequest(url, requestOptions);
-  }
-
-  async function put(url, body, json, options) {
-    const requestOptions = _objectSpread(_objectSpread({
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(body)
-    }, options), {}, {
-      json
-    });
-
-    return _httpRequest(url, requestOptions);
-  }
-
-  async function _delete(url, json, options) {
-    // Prefixed with underscored because delete is a reserved word in javascript
-    const requestOptions = _objectSpread(_objectSpread({
-      method: 'DELETE'
-    }, options), {}, {
-      json
-    });
-
-    return _httpRequest(url, requestOptions);
-  } // Helper function to parse a response as JSON (Probably not needed in the future and could be replaced with Response.json())
-
-
-  async function JSONhandleResponse(response) {
-    const text = await response.text();
-    const data = text && JSON.parse(text);
-
-    if (!response.ok) {
-      const error = data && data.message || response.statusText;
-      return Promise.reject(error);
-    }
-
-    return data;
   } // Export of the functions that should be available for external use.
 
 
-  const cachingClient = {
-    clearUnknownCache,
-    clearCache,
-    get,
-    options,
-    post,
-    put,
-    delete: _delete
-  };
-  _exports.cachingClient = cachingClient;
+  var _default = CachingClient;
+  _exports.default = _default;
 });

--- a/cachingClient/package.json
+++ b/cachingClient/package.json
@@ -2,7 +2,7 @@
   "name": "caching-client",
   "version": "0.1.0",
   "description": "Example Caching Client (HTTP Client using the Cache API). This example cache any request that is made using the available functions.",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "test": "jest",
     "build:demo": "babel src/index.js -d demo",

--- a/cachingClient/src/index.js
+++ b/cachingClient/src/index.js
@@ -6,236 +6,234 @@
 
 // ----- Constants and values (probably need to be configurable)
 
-const CACHE_VERSION = 1;
-const CURRENT_CACHES = {
-  'read-through': 'read-through-cache-v' + CACHE_VERSION
-};
-const CURRENT_CACHE = 'read-through';
-const JSON_SCHEMA_REL_HEADER = 'rel=\'describedBy\'';
-const JSON_SCHEMA_ENVELOP_TYPE = 'https://api.openteams.com/json-schema/Envelope';
+class CachingClient extends EventTarget{
 
-// ----- Cache handling
-
-// Clears unhandled caches
-async function clearUnknownCache(){
-    const expectedCacheNames = Object.keys(CURRENT_CACHES).map(function(key) {
-        return CURRENT_CACHES[key];
-    });
-    const cacheNames = await caches.keys()
-    return Promise.all(
-        cacheNames.map(function(cacheName) {
-            if (expectedCacheNames.indexOf(cacheName) === -1) {
-                // If this cache name isn't present in the array of "expected" cache names, then delete it.
-                // console.log('Deleting out of date cache:', cacheName);
-                return caches.delete(cacheName);
-            }
-        })
-    );
-}
-
-// Clear the current cache (CURRENT_CACHE)
-async function clearCache(){
-    return await caches.delete(CURRENT_CACHES[CURRENT_CACHE]);
-}
-
-// Retrieve and cache a response from a new request or retrieve response from cache
-async function cacheRequest(request) {
-    const cache = await caches.open(CURRENT_CACHES['read-through'])
-    let cacheResponse = await cache.match(request.url);
-    if (cacheResponse) {
-        // If there is an entry in the cache for request.url, then response will be defined
-        // and we can just return it for now.
-        // TODO: Add a way to check if an update to the cache is needed
-        // e.g do a HEAD request to check cache headers for the resource.
-        // console.log(' Found response in cache:', cacheResponse);
-        return cacheResponse;
+    constructor(cache_version=1, current_cache='read-through',
+                json_schema_rel_header='rel=\'describedBy\'',
+                json_schema_envelop_type='https://api.openteams.com/json-schema/Envelope'){
+        super();
+        this.cache_version = cache_version;
+        this.current_cache = current_cache;
+        this.current_caches = {};
+        this.current_caches[current_cache] = `${current_cache}-cache-v${cache_version}`;
+        this.json_schema_rel_header = json_schema_rel_header;
+        this.json_schema_envelop_type = json_schema_envelop_type;
     }
-
-    // Otherwise, if there is no entry in the cache for request.url, response will be
-    // undefined, and we need to fetch() the resource.
-    // console.log(' No response for %s found in cache. ' + 'About to fetch from network...', request.url);
-
-    // We call .clone() on the request since we might use it in the call to cache.put() later on.
-    // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
-    // (see https://fetch.spec.whatwg.org/#dom-request-clone)
-    const fetchResponse = await fetch(request.clone());
-    // console.log('  Response for %s from network is: %O', request.url, fetchResponse);
-
-    // Optional: Add in extra conditions here, e.g. response.type == 'basic' to only cache
-    // responses from the same domain. See https://fetch.spec.whatwg.org/#concept-response-type
-    if (fetchResponse.status < 400) {
-        // This avoids caching responses that we know are errors (i.e. HTTP status code of 4xx or 5xx).
-        // One limitation is that, for non-CORS requests, we get back a filtered opaque response
-        // (https://fetch.spec.whatwg.org/#concept-filtered-response-opaque) which will always have a
-        // .status of 0, regardless of whether the underlying HTTP call was successful. Since we're
-        // blindly caching those opaque responses, we run the risk of caching a transient error response.
-        //
-        // We need to call .clone() on the response object to save a copy of it to the cache.
-        // (https://fetch.spec.whatwg.org/#dom-request-clone)
-        const unwrappResources = await getUnwrappedResources(fetchResponse.clone());
-        if( unwrappResources.length > 0 ) {
-            // Get Headers and content from response body, get response read-only values,
-            // cache response content with the headers extracted and values found.
-            for (const unwrappResource of unwrappResources) {
-                const {ok, redirected, status, statusText} = fetchResponse;
-                const {headers, body, url} = unwrappResource;
-                const unWrappResponse = new Response(body, {headers, status, statusText, url});
-
-                // Set response read only values that aren't available in the Response constructor.
-                Object.defineProperty(unWrappResponse, 'url', {value: url});
-                Object.defineProperty(unWrappResponse, 'ok', {value: ok});
-                Object.defineProperty(unWrappResponse, 'redirected', {value: redirected});
-                cache.put(url, unWrappResponse);
+    // ----- Cache handling
+    
+    // Clears unhandled caches
+    clearUnknownCache = async () => {
+        const expectedCacheNames = Object.keys(this.current_caches).map(function(key) {
+            return this.current_caches[key];
+        });
+        const cacheNames = await caches.keys()
+        return Promise.all(
+            cacheNames.map(function(cacheName) {
+                if (expectedCacheNames.indexOf(cacheName) === -1) {
+                    // If this cache name isn't present in the array of "expected" cache names, then delete it.
+                    // console.log('Deleting out of date cache:', cacheName);
+                    return caches.delete(cacheName);
+                }
+            })
+        );
+    }
+    
+    // Clear the current cache (current_cache)
+    clearCache = async () => {
+        return await caches.delete(this.current_caches[this.current_cache]);
+    }
+    
+    // Retrieve and cache a response from a new request or retrieve response from cache
+    cacheRequest = async (request) => {
+        const cache = await caches.open(this.current_caches[this.current_cache])
+        let cacheResponse = await cache.match(request.url);
+        if (cacheResponse) {
+            // If there is an entry in the cache for request.url, then response will be defined
+            // and we can just return it for now.
+            // TODO: Add a way to check if an update to the cache is needed
+            // e.g do a HEAD request to check cache headers for the resource.
+            // console.log(' Found response in cache:', cacheResponse);
+            return cacheResponse;
+        }
+    
+        // Otherwise, if there is no entry in the cache for request.url, response will be
+        // undefined, and we need to fetch() the resource.
+        // console.log(' No response for %s found in cache. ' + 'About to fetch from network...', request.url);
+    
+        // We call .clone() on the request since we might use it in the call to cache.put() later on.
+        // Both fetch() and cache.put() "consume" the request, so we need to make a copy.
+        // (see https://fetch.spec.whatwg.org/#dom-request-clone)
+        const fetchResponse = await fetch(request.clone());
+        // console.log('  Response for %s from network is: %O', request.url, fetchResponse);
+    
+        // Optional: Add in extra conditions here, e.g. response.type == 'basic' to only cache
+        // responses from the same domain. See https://fetch.spec.whatwg.org/#concept-response-type
+        if (fetchResponse.status < 400) {
+            // This avoids caching responses that we know are errors (i.e. HTTP status code of 4xx or 5xx).
+            // One limitation is that, for non-CORS requests, we get back a filtered opaque response
+            // (https://fetch.spec.whatwg.org/#concept-filtered-response-opaque) which will always have a
+            // .status of 0, regardless of whether the underlying HTTP call was successful. Since we're
+            // blindly caching those opaque responses, we run the risk of caching a transient error response.
+            //
+            // We need to call .clone() on the response object to save a copy of it to the cache.
+            // (https://fetch.spec.whatwg.org/#dom-request-clone)
+            const unwrappResources = await this._getUnwrappedResources(fetchResponse.clone());
+            if( unwrappResources.length > 0 ) {
+                // Get Headers and content from response body, get response read-only values,
+                // cache response content with the headers extracted and values found.
+                for (const unwrappResource of unwrappResources) {
+                    const {ok, redirected, status, statusText} = fetchResponse;
+                    const {headers, body, url} = unwrappResource;
+                    const unWrappResponse = new Response(body, {headers, status, statusText, url});
+    
+                    // Set response read only values that aren't available in the Response constructor.
+                    Object.defineProperty(unWrappResponse, 'url', {value: url});
+                    Object.defineProperty(unWrappResponse, 'ok', {value: ok});
+                    Object.defineProperty(unWrappResponse, 'redirected', {value: redirected});
+                    cache.put(url, unWrappResponse);
+                }
+            }
+            cache.put(request.url, fetchResponse.clone());
+        }
+    
+        // Return the original response object, which will be used to fulfill the resource request.
+        return fetchResponse;
+    }
+    
+    // ----- Envelop handling functions
+    
+    // Extract information from an envelop. Get the headers, body and url from the envelop provided.
+    _unwrappEnvelop = (envelop) => {
+        const {etag, last_modified, url, content} = envelop;
+        const headers = {ETag: etag, 'Last-Modified': last_modified}
+    
+        return {headers,
+                body: JSON.stringify(content),
+                url};
+    }
+    
+    // Detect that a response is an Envelop and retrieve a list of unwrapped envelopes if needed.
+     _getUnwrappedResources = async (response) => {
+        const responseLinks = this._parseLinkHeader(response.headers);
+        const jsonSchemaURI = responseLinks[this.json_schema_rel_header];
+        const unwrappedResources = [];
+        if(jsonSchemaURI && jsonSchemaURI !== response.url){
+            const schema = await this.get(jsonSchemaURI, true);
+            const schemaId = schema.$id;
+            const schemaItems = schema.properties.content.properties.items;
+            if (schemaId == this.json_schema_envelop_type){
+                // Handle single resource
+                unwrappedResources.push(this._unwrappEnvelop(await response.json()));
+                return unwrappedResources;
+            } else if (schemaItems && schemaItems.$ref == this.json_schema_envelop_type) {
+                // Handle array of resources
+                const content = await response.json();
+                for (const envelop of content) {
+                    unwrappedResources.push(this._unwrappEnvelop(envelop));
+                }
             }
         }
-        cache.put(request.url, fetchResponse.clone());
+        return unwrappedResources;
     }
-
-    // Return the original response object, which will be used to fulfill the resource request.
-    return fetchResponse;
-}
-
-// ----- Envelop handling functions
-
-// Extract information from an envelop. Get the headers, body and url from the envelop provided.
-function unwrappEnvelop(envelop){
-    const {etag, last_modified, url, content} = envelop;
-    const headers = {ETag: etag, 'Last-Modified': last_modified}
-
-    return {headers,
-            body: JSON.stringify(content),
-            url};
-}
-
-// Detect that a response is an Envelop and retrieve a list of unwrapped envelopes if needed.
-async function getUnwrappedResources(response){
-    const responseLinks = _parseLinkHeader(response.headers);
-    const jsonSchemaURI = responseLinks[JSON_SCHEMA_REL_HEADER];
-    const unwrappedResources = [];
-    if(jsonSchemaURI && jsonSchemaURI !== response.url){
-        const schema = await get(jsonSchemaURI, true);
-        const schemaId = schema.$id;
-        const schemaItems = schema.properties.content.properties.items;
-        if (schemaId == JSON_SCHEMA_ENVELOP_TYPE){
-            // Handle single resource
-            unwrappedResources.push(unwrappEnvelop(await response.json()));
-            return unwrappedResources;
-        } else if (schemaItems && schemaItems.$ref == JSON_SCHEMA_ENVELOP_TYPE) {
-            // Handle array of resources
-            const content = await response.json();
-            for (const envelop of content) {
-                unwrappedResources.push(unwrappEnvelop(envelop));
+    
+    // ----- Helper functions to cache requests
+    _httpRequest = async (url, requestOptions) => {
+        try{
+            const response = await this.cacheRequest(new Request(url, requestOptions))
+            return requestOptions.json? await this._JSONhandleResponse(response): response;
+        } catch(err) {
+            console.error('Error while catching the request', err);
+        }
+    }
+    
+    // Parse link headers and retrieve an object {rel0: url0, rel1: url1}
+    _parseLinkHeader = (headers) => {
+        // Taken from: https://gist.github.com/niallo/3109252#gistcomment-2883309
+        const header = headers.get('Link');
+        if (!header || header.length === 0) {
+            return {};
+        }
+    
+        // Split parts by comma and parse each part into a named link
+        const found = header.split(/(?!\B"[^"]*),(?![^"]*"\B)/).reduce((links, part) => {
+            const section = part.split(/(?!\B"[^"]*);(?![^"]*"\B)/);
+            if (section.length < 2) {
+                throw new Error("Section could not be split on ';'");
             }
+            const url = section[0].replace(/<(.*)>/, '$1').trim();
+            const name = section[1].replace(/rel="(.*)"/, '$1').trim();
+    
+            links[name] = url;
+    
+            return links;
+        }, {});
+    
+        return found;
+    }
+    
+    // Helper function to parse a response as JSON (Probably not needed in the future and could be replaced with Response.json())
+    _JSONhandleResponse = async (response) => {
+        const text = await response.text();
+        const data = text && JSON.parse(text);
+        if (!response.ok) {
+            const error = (data && data.message) || response.statusText;
+            return Promise.reject(error);
         }
-    }
-    return unwrappedResources;
-}
-
-// ----- Helper functions to cache requests
-async function _httpRequest(url, requestOptions) {
-    try{
-        const response = await cacheRequest(new Request(url, requestOptions))
-        return requestOptions.json? await JSONhandleResponse(response): response;
-    } catch(err) {
-        console.error('Error while catching the request', err);
-    }
-}
-
-// Parse link headers and retrieve an object {rel0: url0, rel1: url1}
-function _parseLinkHeader(headers) {
-    // Taken from: https://gist.github.com/niallo/3109252#gistcomment-2883309
-    const header = headers.get('Link');
-    if (!header || header.length === 0) {
-        return {};
+        return data;
     }
 
-    // Split parts by comma and parse each part into a named link
-    const found = header.split(/(?!\B"[^"]*),(?![^"]*"\B)/).reduce((links, part) => {
-        const section = part.split(/(?!\B"[^"]*);(?![^"]*"\B)/);
-        if (section.length < 2) {
-            throw new Error("Section could not be split on ';'");
-        }
-        const url = section[0].replace(/<(.*)>/, '$1').trim();
-        const name = section[1].replace(/rel="(.*)"/, '$1').trim();
-
-        links[name] = url;
-
-        return links;
-    }, {});
-
-    return found;
-}
-
-// ----- Requests available (GET, OPTIONS, POST, PUT, DELETE)
-
-async function get(url, json, options) {
-    const requestOptions = {
-        method: 'GET',
-        ...options,
-        json
-    };
-    return _httpRequest(url, requestOptions);
-}
-
-async function options(url, json, options) {
-    const requestOptions = {
-        method: 'OPTIONS',
-        ...options,
-        json
-    };
-    return _httpRequest(url, requestOptions);
-}
-
-async function post(url, body, json, options) {
-    const requestOptions = {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-        ...options,
-        json
-    };
-    return _httpRequest(url, requestOptions);
-}
-
-async function put(url, body, json, options) {
-    const requestOptions = {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-        ...options,
-        json
-    };
-    return _httpRequest(url, requestOptions);
-}
-
-async function _delete(url, json, options) {
-    // Prefixed with underscored because delete is a reserved word in javascript
-    const requestOptions = {
-        method: 'DELETE',
-        ...options,
-        json
-    };
-    return _httpRequest(url, requestOptions);
-}
-
-// Helper function to parse a response as JSON (Probably not needed in the future and could be replaced with Response.json())
-async function JSONhandleResponse(response) {
-    const text = await response.text();
-    const data = text && JSON.parse(text);
-    if (!response.ok) {
-        const error = (data && data.message) || response.statusText;
-        return Promise.reject(error);
+    // ----- Requests available (GET, OPTIONS, POST, PUT, DELETE)
+    
+    get = async (url, json, options) => {
+        const requestOptions = {
+            method: 'GET',
+            ...options,
+            json
+        };
+        return this._httpRequest(url, requestOptions);
     }
-    return data;
+    
+    options = async (url, json, options) => {
+        const requestOptions = {
+            method: 'OPTIONS',
+            ...options,
+            json
+        };
+        return this._httpRequest(url, requestOptions);
+    }
+    
+    post = async (url, body, json, options) => {
+        const requestOptions = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+            ...options,
+            json
+        };
+        return this._httpRequest(url, requestOptions);
+    }
+    
+    put = async (url, body, json, options) => {
+        const requestOptions = {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+            ...options,
+            json
+        };
+        return this._httpRequest(url, requestOptions);
+    }
+    
+    delete = async (url, json, options) => {
+        const requestOptions = {
+            method: 'DELETE',
+            ...options,
+            json
+        };
+        return this._httpRequest(url, requestOptions);
+    }
+
 }
 
 // Export of the functions that should be available for external use.
-export const cachingClient = {
-    clearUnknownCache,
-    clearCache,
-    get,
-    options,
-    post,
-    put,
-    delete: _delete
-};
+export default CachingClient;

--- a/cachingClient/test/index.test.js
+++ b/cachingClient/test/index.test.js
@@ -30,9 +30,9 @@ describe('caching-client', () => {
         expect(_caches['read-through-cache-v1']).not.toBeUndefined();
         expect(_caches['read-through-cache-v1'][url]).not.toBeUndefined();
         expect(_caches['read-through-cache-v1'][url]).toEqual(expectedResponse);
-   });
+    });
 
-   it('Check GET request - return parsed body', async () => {
+    it('Check GET request - return parsed body', async () => {
         const cachingClient = new CachingClient();    
         // Check the cache is clear
         expect(_caches['read-through-cache-v1']).toBeUndefined();
@@ -54,101 +54,100 @@ describe('caching-client', () => {
     });
 
     it('Check GET request - return cached request', async () => {
-      const cachingClient = new CachingClient();    
-      // Check the cache is clear
-      expect(_caches['read-through-cache-v1']).toBeUndefined();
+        const cachingClient = new CachingClient();    
+        // Check the cache is clear
+        expect(_caches['read-through-cache-v1']).toBeUndefined();
 
-      // Setup mock request
-      const url = 'https://mock.com/todo/1';
-      const expectedBody = [{'completed': false, 'id': 1, 'title': 'delectus aut autem', 'userId': 1}, {'completed': false, 'id': 2, 'title': 'quis ut nam facilis et officia qui', 'userId': 1}, {'completed': false, 'id': 3, 'title': 'fugiat veniam minus', 'userId': 1}, {'completed': true, 'id': 4, 'title': 'et porro tempora', 'userId': 1}, {'completed': false, 'id': 5, 'title': 'laboriosam mollitia et enim quasi adipisci quia provident illum', 'userId': 1}, {'completed': false, 'id': 6, 'title': 'qui ullam ratione quibusdam voluptatem quia omnis', 'userId': 1}, {'completed': false, 'id': 7, 'title': 'illo expedita consequatur quia in', 'userId': 1}, {'completed': true, 'id': 8, 'title': 'quo adipisci enim quam ut ab', 'userId': 1}, {'completed': false, 'id': 9, 'title': 'molestiae perspiciatis ipsa', 'userId': 1}, {'completed': true, 'id': 10, 'title': 'illo est ratione doloremque quia maiores aut', 'userId': 1}, {'completed': true, 'id': 11, 'title': 'vero rerum temporibus dolor', 'userId': 1}, {'completed': true, 'id': 12, 'title': 'ipsa repellendus fugit nisi', 'userId': 1}, {'completed': false, 'id': 13, 'title': 'et doloremque nulla', 'userId': 1}, {'completed': true, 'id': 14, 'title': 'repellendus sunt dolores architecto voluptatum', 'userId': 1}, {'completed': true, 'id': 15, 'title': 'ab voluptatum amet voluptas', 'userId': 1}, {'completed': true, 'id': 16, 'title': 'accusamus eos facilis sint et aut voluptatem', 'userId': 1}, {'completed': true, 'id': 17, 'title': 'quo laboriosam deleniti aut qui', 'userId': 1}, {'completed': false, 'id': 18, 'title': 'dolorum est consequatur ea mollitia in culpa', 'userId': 1}, {'completed': true, 'id': 19, 'title': 'molestiae ipsa aut voluptatibus pariatur dolor nihil', 'userId': 1}, {'completed': true, 'id': 20, 'title': 'ullam nobis libero sapiente ad optio sint', 'userId': 1}];
-      fetch.mockResponseOnce(JSON.stringify(expectedBody), {url, method: CachingClient.GET,
-                                                            headers:{
-                                                                'Last-modified': 'Mon, 13 July 2020 12:12:12 GMT',
-                                                                ETag: 'XXXXX',
-                                                            }})
-           .mockResponseOnce(null, {url, method: CachingClient.HEAD,
-                                    headers:{
-                                      'Last-modified': 'Mon, 13 July 2020 12:12:12 GMT',
-                                      ETag: 'XXXXX',
-                                    }});
-      
-      // Make the request
-      const responseBody = await cachingClient.get(url, {json: true});
+        // Setup mock request
+        const url = 'https://mock.com/todo/1';
+        const expectedBody = [{'completed': false, 'id': 1, 'title': 'delectus aut autem', 'userId': 1}, {'completed': false, 'id': 2, 'title': 'quis ut nam facilis et officia qui', 'userId': 1}, {'completed': false, 'id': 3, 'title': 'fugiat veniam minus', 'userId': 1}, {'completed': true, 'id': 4, 'title': 'et porro tempora', 'userId': 1}, {'completed': false, 'id': 5, 'title': 'laboriosam mollitia et enim quasi adipisci quia provident illum', 'userId': 1}, {'completed': false, 'id': 6, 'title': 'qui ullam ratione quibusdam voluptatem quia omnis', 'userId': 1}, {'completed': false, 'id': 7, 'title': 'illo expedita consequatur quia in', 'userId': 1}, {'completed': true, 'id': 8, 'title': 'quo adipisci enim quam ut ab', 'userId': 1}, {'completed': false, 'id': 9, 'title': 'molestiae perspiciatis ipsa', 'userId': 1}, {'completed': true, 'id': 10, 'title': 'illo est ratione doloremque quia maiores aut', 'userId': 1}, {'completed': true, 'id': 11, 'title': 'vero rerum temporibus dolor', 'userId': 1}, {'completed': true, 'id': 12, 'title': 'ipsa repellendus fugit nisi', 'userId': 1}, {'completed': false, 'id': 13, 'title': 'et doloremque nulla', 'userId': 1}, {'completed': true, 'id': 14, 'title': 'repellendus sunt dolores architecto voluptatum', 'userId': 1}, {'completed': true, 'id': 15, 'title': 'ab voluptatum amet voluptas', 'userId': 1}, {'completed': true, 'id': 16, 'title': 'accusamus eos facilis sint et aut voluptatem', 'userId': 1}, {'completed': true, 'id': 17, 'title': 'quo laboriosam deleniti aut qui', 'userId': 1}, {'completed': false, 'id': 18, 'title': 'dolorum est consequatur ea mollitia in culpa', 'userId': 1}, {'completed': true, 'id': 19, 'title': 'molestiae ipsa aut voluptatibus pariatur dolor nihil', 'userId': 1}, {'completed': true, 'id': 20, 'title': 'ullam nobis libero sapiente ad optio sint', 'userId': 1}];
+        fetch.mockResponseOnce(JSON.stringify(expectedBody), {url, method: CachingClient.GET,
+                                                              headers:{
+                                                                  'Last-modified': 'Mon, 13 July 2020 12:12:12 GMT',
+                                                                  ETag: 'XXXXX',
+                                                              }})
+            .mockResponseOnce(null, {url, method: CachingClient.HEAD,
+                                      headers:{
+                                        'Last-modified': 'Mon, 13 July 2020 12:12:12 GMT',
+                                        ETag: 'XXXXX',
+                                      }});
+        
+        // Make the request
+        const responseBody = await cachingClient.get(url, {json: true});
 
-      // Assert response body is correct
-      expect(responseBody).toEqual(expectedBody);
+        // Assert response body is correct
+        expect(responseBody).toEqual(expectedBody);
 
-      // Assert the cache entry for the request
-      expect(_caches['read-through-cache-v1']).not.toBeUndefined();
-      expect(_caches['read-through-cache-v1'][url]).not.toBeUndefined();
+        // Assert the cache entry for the request
+        expect(_caches['read-through-cache-v1']).not.toBeUndefined();
+        expect(_caches['read-through-cache-v1'][url]).not.toBeUndefined();
 
-      // Make the request again
-      const responseBodyCached = await cachingClient.get(url, {json: true});
-      // Assert response body is correct
-      expect(responseBodyCached).toEqual(expectedBody);
-      // Assert fetch has been called (one for the inital GET request and one for the HEAD to check
-      // the available cached response freshness).
-      expect(fetch).toHaveBeenCalled();
-      expect(fetch).toHaveBeenCalledTimes(2);
-      // Assert methods of the request: (1) GET, (2) HEAD
-      expect(fetch.mock.calls[0][0]['method']).toBe(CachingClient.GET);
-      expect(fetch.mock.calls[1][0]['method']).toBe(CachingClient.HEAD);
+        // Make the request again
+        const responseBodyCached = await cachingClient.get(url, {json: true});
+        // Assert response body is correct
+        expect(responseBodyCached).toEqual(expectedBody);
+        // Assert fetch has been called (one for the inital GET request and one for the HEAD to check
+        // the available cached response freshness).
+        expect(fetch).toHaveBeenCalled();
+        expect(fetch).toHaveBeenCalledTimes(2);
+        // Assert methods of the request: (1) GET, (2) HEAD
+        expect(fetch.mock.calls[0][0]['method']).toBe(CachingClient.GET);
+        expect(fetch.mock.calls[1][0]['method']).toBe(CachingClient.HEAD);
     });
 
     it('Check GET request - update cached request and dispatch update event', async () => {
-      const cachingClient = new CachingClient();
-      // Check the cache is clear
-      expect(_caches['read-through-cache-v1']).toBeUndefined();
+        const cachingClient = new CachingClient();
+        // Check the cache is clear
+        expect(_caches['read-through-cache-v1']).toBeUndefined();
 
-      // Setup mock request
-      const url = 'https://mock.com/todo/1';
-      const expectedBody = [{'completed': false, 'id': 1, 'title': 'delectus aut autem', 'userId': 1}, {'completed': false, 'id': 2, 'title': 'quis ut nam facilis et officia qui', 'userId': 1}, {'completed': false, 'id': 3, 'title': 'fugiat veniam minus', 'userId': 1}, {'completed': true, 'id': 4, 'title': 'et porro tempora', 'userId': 1}, {'completed': false, 'id': 5, 'title': 'laboriosam mollitia et enim quasi adipisci quia provident illum', 'userId': 1}, {'completed': false, 'id': 6, 'title': 'qui ullam ratione quibusdam voluptatem quia omnis', 'userId': 1}, {'completed': false, 'id': 7, 'title': 'illo expedita consequatur quia in', 'userId': 1}, {'completed': true, 'id': 8, 'title': 'quo adipisci enim quam ut ab', 'userId': 1}, {'completed': false, 'id': 9, 'title': 'molestiae perspiciatis ipsa', 'userId': 1}, {'completed': true, 'id': 10, 'title': 'illo est ratione doloremque quia maiores aut', 'userId': 1}, {'completed': true, 'id': 11, 'title': 'vero rerum temporibus dolor', 'userId': 1}, {'completed': true, 'id': 12, 'title': 'ipsa repellendus fugit nisi', 'userId': 1}, {'completed': false, 'id': 13, 'title': 'et doloremque nulla', 'userId': 1}, {'completed': true, 'id': 14, 'title': 'repellendus sunt dolores architecto voluptatum', 'userId': 1}, {'completed': true, 'id': 15, 'title': 'ab voluptatum amet voluptas', 'userId': 1}, {'completed': true, 'id': 16, 'title': 'accusamus eos facilis sint et aut voluptatem', 'userId': 1}, {'completed': true, 'id': 17, 'title': 'quo laboriosam deleniti aut qui', 'userId': 1}, {'completed': false, 'id': 18, 'title': 'dolorum est consequatur ea mollitia in culpa', 'userId': 1}, {'completed': true, 'id': 19, 'title': 'molestiae ipsa aut voluptatibus pariatur dolor nihil', 'userId': 1}, {'completed': true, 'id': 20, 'title': 'ullam nobis libero sapiente ad optio sint', 'userId': 1}];
-      fetch.mockResponseOnce(JSON.stringify(expectedBody), {url, method: CachingClient.GET,
+        // Setup mock request
+        const url = 'https://mock.com/todo/1';
+        const expectedBody = [{'completed': false, 'id': 1, 'title': 'delectus aut autem', 'userId': 1}, {'completed': false, 'id': 2, 'title': 'quis ut nam facilis et officia qui', 'userId': 1}, {'completed': false, 'id': 3, 'title': 'fugiat veniam minus', 'userId': 1}, {'completed': true, 'id': 4, 'title': 'et porro tempora', 'userId': 1}, {'completed': false, 'id': 5, 'title': 'laboriosam mollitia et enim quasi adipisci quia provident illum', 'userId': 1}, {'completed': false, 'id': 6, 'title': 'qui ullam ratione quibusdam voluptatem quia omnis', 'userId': 1}, {'completed': false, 'id': 7, 'title': 'illo expedita consequatur quia in', 'userId': 1}, {'completed': true, 'id': 8, 'title': 'quo adipisci enim quam ut ab', 'userId': 1}, {'completed': false, 'id': 9, 'title': 'molestiae perspiciatis ipsa', 'userId': 1}, {'completed': true, 'id': 10, 'title': 'illo est ratione doloremque quia maiores aut', 'userId': 1}, {'completed': true, 'id': 11, 'title': 'vero rerum temporibus dolor', 'userId': 1}, {'completed': true, 'id': 12, 'title': 'ipsa repellendus fugit nisi', 'userId': 1}, {'completed': false, 'id': 13, 'title': 'et doloremque nulla', 'userId': 1}, {'completed': true, 'id': 14, 'title': 'repellendus sunt dolores architecto voluptatum', 'userId': 1}, {'completed': true, 'id': 15, 'title': 'ab voluptatum amet voluptas', 'userId': 1}, {'completed': true, 'id': 16, 'title': 'accusamus eos facilis sint et aut voluptatem', 'userId': 1}, {'completed': true, 'id': 17, 'title': 'quo laboriosam deleniti aut qui', 'userId': 1}, {'completed': false, 'id': 18, 'title': 'dolorum est consequatur ea mollitia in culpa', 'userId': 1}, {'completed': true, 'id': 19, 'title': 'molestiae ipsa aut voluptatibus pariatur dolor nihil', 'userId': 1}, {'completed': true, 'id': 20, 'title': 'ullam nobis libero sapiente ad optio sint', 'userId': 1}];
+        fetch.mockResponseOnce(JSON.stringify(expectedBody), {url, method: CachingClient.GET,
+                                                              headers:{
+                                                                  'Last-modified': 'Mon, 13 July 2020 12:12:12 GMT',
+                                                                  ETag: 'XXXXX',
+                                                              }})
+            .mockResponseOnce(null, {url, method: CachingClient.HEAD,
+                                      headers:{
+                                        'Last-modified': 'Mon, 14 July 2020 12:12:12 GMT',
+                                        ETag: 'XXXXX',
+                                      }})
+            .mockResponseOnce(JSON.stringify(expectedBody), {url, method: CachingClient.GET,
                                                             headers:{
-                                                                'Last-modified': 'Mon, 13 July 2020 12:12:12 GMT',
+                                                                'Last-modified': 'Mon, 14 July 2020 12:12:12 GMT',
                                                                 ETag: 'XXXXX',
-                                                            }})
-          .mockResponseOnce(null, {url, method: CachingClient.HEAD,
-                                    headers:{
-                                      'Last-modified': 'Mon, 14 July 2020 12:12:12 GMT',
-                                      ETag: 'XXXXX',
-                                    }})
-          .mockResponseOnce(JSON.stringify(expectedBody), {url, method: CachingClient.GET,
-                                                          headers:{
-                                                              'Last-modified': 'Mon, 14 July 2020 12:12:12 GMT',
-                                                              ETag: 'XXXXX',
-                                                          }});
+                                                            }});
 
-      // Make the request passing a callback to recieve event of cache update
-      const cacheUpdateHandler = jest.fn((event) => {
-                                          expect(event).not.toBeUndefined();
-                                          expect(event.detail).not.toBeUndefined();
-                                          expect(event.detail.url).toEqual(url);
+        // Make the request passing a callback to recieve event of cache update
+        const cacheUpdateHandler = jest.fn((event) => {
+                                            expect(event).not.toBeUndefined();
+                                            expect(event.detail).not.toBeUndefined();
+                                            expect(event.detail.url).toEqual(url);
 
-                                        });
-      const responseBody = await cachingClient.get(url, {json: true, callback: cacheUpdateHandler});
+                                          });
+        const responseBody = await cachingClient.get(url, {json: true, callback: cacheUpdateHandler});
 
-      // Assert response body is correct
-      expect(responseBody).toEqual(expectedBody);
+        // Assert response body is correct
+        expect(responseBody).toEqual(expectedBody);
 
-      // Assert the cache entry for the request
-      expect(_caches['read-through-cache-v1']).not.toBeUndefined();
-      expect(_caches['read-through-cache-v1'][url]).not.toBeUndefined();
+        // Assert the cache entry for the request
+        expect(_caches['read-through-cache-v1']).not.toBeUndefined();
+        expect(_caches['read-through-cache-v1'][url]).not.toBeUndefined();
 
-      // Make the request again
-      const responseBodyCached = await cachingClient.get(url, {json: true});
-      // Assert response body is correct
-      expect(responseBodyCached).toEqual(expectedBody);
-      // Assert fetch has been called (one for the inital GET request, one for the HEAD to check
-      // the available cached response freshness and one to update the cached response).
-      expect(fetch).toHaveBeenCalled();
-      expect(fetch).toHaveBeenCalledTimes(3);
-      expect(cacheUpdateHandler).toHaveBeenCalled();
-      expect(cacheUpdateHandler).toHaveBeenCalledTimes(1);
-
+        // Make the request again
+        const responseBodyCached = await cachingClient.get(url, {json: true});
+        // Assert response body is correct
+        expect(responseBodyCached).toEqual(expectedBody);
+        // Assert fetch has been called (one for the inital GET request, one for the HEAD to check
+        // the available cached response freshness and one to update the cached response).
+        expect(fetch).toHaveBeenCalled();
+        expect(fetch).toHaveBeenCalledTimes(3);
+        expect(cacheUpdateHandler).toHaveBeenCalled();
+        expect(cacheUpdateHandler).toHaveBeenCalledTimes(1);
     });
 
-   it('Check GET request - envelop properties handling', async () => {
+    it('Check GET request - envelop properties handling', async () => {
         const cachingClient = new CachingClient();    
         // Check the cache is clear
         expect(_caches['read-through-cache-v1']).toBeUndefined();

--- a/cachingClient/test/index.test.js
+++ b/cachingClient/test/index.test.js
@@ -1,13 +1,15 @@
-import {cachingClient} from '../src/index';
+import CachingClient from '../src/index';
 
 describe('caching-client', () => {
 
     beforeEach(()=>{
         fetch.resetMocks();
+        const cachingClient = new CachingClient();
         cachingClient.clearCache();
     });
 
     it('Check GET request - return Response object', async () => {
+        const cachingClient = new CachingClient();
         // Check the cache is clear
         expect(_caches['read-through-cache-v1']).toBeUndefined();
 
@@ -31,6 +33,7 @@ describe('caching-client', () => {
    });
 
    it('Check GET request - return parsed body', async () => {
+        const cachingClient = new CachingClient();    
         // Check the cache is clear
         expect(_caches['read-through-cache-v1']).toBeUndefined();
 
@@ -51,6 +54,7 @@ describe('caching-client', () => {
     });
 
    it('Check envelop properties handling', async () => {
+        const cachingClient = new CachingClient();    
         // Check the cache is clear
         expect(_caches['read-through-cache-v1']).toBeUndefined();
 

--- a/cachingClient/test/index.test.js
+++ b/cachingClient/test/index.test.js
@@ -61,7 +61,16 @@ describe('caching-client', () => {
       // Setup mock request
       const url = 'https://mock.com/todo/1';
       const expectedBody = [{'completed': false, 'id': 1, 'title': 'delectus aut autem', 'userId': 1}, {'completed': false, 'id': 2, 'title': 'quis ut nam facilis et officia qui', 'userId': 1}, {'completed': false, 'id': 3, 'title': 'fugiat veniam minus', 'userId': 1}, {'completed': true, 'id': 4, 'title': 'et porro tempora', 'userId': 1}, {'completed': false, 'id': 5, 'title': 'laboriosam mollitia et enim quasi adipisci quia provident illum', 'userId': 1}, {'completed': false, 'id': 6, 'title': 'qui ullam ratione quibusdam voluptatem quia omnis', 'userId': 1}, {'completed': false, 'id': 7, 'title': 'illo expedita consequatur quia in', 'userId': 1}, {'completed': true, 'id': 8, 'title': 'quo adipisci enim quam ut ab', 'userId': 1}, {'completed': false, 'id': 9, 'title': 'molestiae perspiciatis ipsa', 'userId': 1}, {'completed': true, 'id': 10, 'title': 'illo est ratione doloremque quia maiores aut', 'userId': 1}, {'completed': true, 'id': 11, 'title': 'vero rerum temporibus dolor', 'userId': 1}, {'completed': true, 'id': 12, 'title': 'ipsa repellendus fugit nisi', 'userId': 1}, {'completed': false, 'id': 13, 'title': 'et doloremque nulla', 'userId': 1}, {'completed': true, 'id': 14, 'title': 'repellendus sunt dolores architecto voluptatum', 'userId': 1}, {'completed': true, 'id': 15, 'title': 'ab voluptatum amet voluptas', 'userId': 1}, {'completed': true, 'id': 16, 'title': 'accusamus eos facilis sint et aut voluptatem', 'userId': 1}, {'completed': true, 'id': 17, 'title': 'quo laboriosam deleniti aut qui', 'userId': 1}, {'completed': false, 'id': 18, 'title': 'dolorum est consequatur ea mollitia in culpa', 'userId': 1}, {'completed': true, 'id': 19, 'title': 'molestiae ipsa aut voluptatibus pariatur dolor nihil', 'userId': 1}, {'completed': true, 'id': 20, 'title': 'ullam nobis libero sapiente ad optio sint', 'userId': 1}];
-      fetch.mockResponseOnce(JSON.stringify(expectedBody), {url});
+      fetch.mockResponseOnce(JSON.stringify(expectedBody), {url, method: CachingClient.GET,
+                                                            headers:{
+                                                                'Last-modified': 'Mon, 13 July 2020 12:12:12 GMT',
+                                                                ETag: 'XXXXX',
+                                                            }})
+           .mockResponseOnce(null, {url, method: CachingClient.HEAD,
+                                    headers:{
+                                      'Last-modified': 'Mon, 13 July 2020 12:12:12 GMT',
+                                      ETag: 'XXXXX',
+                                    }});
       
       // Make the request
       const responseBody = await cachingClient.get(url, {json: true});
@@ -76,10 +85,70 @@ describe('caching-client', () => {
       // Make the request again
       const responseBodyCached = await cachingClient.get(url, {json: true});
       // Assert response body is correct
-      expect(responseBody).toEqual(expectedBody);
-  });
+      expect(responseBodyCached).toEqual(expectedBody);
+      // Assert fetch has been called (one for the inital GET request and one for the HEAD to check
+      // the available cached response freshness).
+      expect(fetch).toHaveBeenCalled();
+      expect(fetch).toHaveBeenCalledTimes(2);
+      // Assert methods of the request: (1) GET, (2) HEAD
+      expect(fetch.mock.calls[0][0]['method']).toBe(CachingClient.GET);
+      expect(fetch.mock.calls[1][0]['method']).toBe(CachingClient.HEAD);
+    });
 
-   it('Check envelop properties handling', async () => {
+    it('Check GET request - update cached request and dispatch update event', async () => {
+      const cachingClient = new CachingClient();
+      // Check the cache is clear
+      expect(_caches['read-through-cache-v1']).toBeUndefined();
+
+      // Setup mock request
+      const url = 'https://mock.com/todo/1';
+      const expectedBody = [{'completed': false, 'id': 1, 'title': 'delectus aut autem', 'userId': 1}, {'completed': false, 'id': 2, 'title': 'quis ut nam facilis et officia qui', 'userId': 1}, {'completed': false, 'id': 3, 'title': 'fugiat veniam minus', 'userId': 1}, {'completed': true, 'id': 4, 'title': 'et porro tempora', 'userId': 1}, {'completed': false, 'id': 5, 'title': 'laboriosam mollitia et enim quasi adipisci quia provident illum', 'userId': 1}, {'completed': false, 'id': 6, 'title': 'qui ullam ratione quibusdam voluptatem quia omnis', 'userId': 1}, {'completed': false, 'id': 7, 'title': 'illo expedita consequatur quia in', 'userId': 1}, {'completed': true, 'id': 8, 'title': 'quo adipisci enim quam ut ab', 'userId': 1}, {'completed': false, 'id': 9, 'title': 'molestiae perspiciatis ipsa', 'userId': 1}, {'completed': true, 'id': 10, 'title': 'illo est ratione doloremque quia maiores aut', 'userId': 1}, {'completed': true, 'id': 11, 'title': 'vero rerum temporibus dolor', 'userId': 1}, {'completed': true, 'id': 12, 'title': 'ipsa repellendus fugit nisi', 'userId': 1}, {'completed': false, 'id': 13, 'title': 'et doloremque nulla', 'userId': 1}, {'completed': true, 'id': 14, 'title': 'repellendus sunt dolores architecto voluptatum', 'userId': 1}, {'completed': true, 'id': 15, 'title': 'ab voluptatum amet voluptas', 'userId': 1}, {'completed': true, 'id': 16, 'title': 'accusamus eos facilis sint et aut voluptatem', 'userId': 1}, {'completed': true, 'id': 17, 'title': 'quo laboriosam deleniti aut qui', 'userId': 1}, {'completed': false, 'id': 18, 'title': 'dolorum est consequatur ea mollitia in culpa', 'userId': 1}, {'completed': true, 'id': 19, 'title': 'molestiae ipsa aut voluptatibus pariatur dolor nihil', 'userId': 1}, {'completed': true, 'id': 20, 'title': 'ullam nobis libero sapiente ad optio sint', 'userId': 1}];
+      fetch.mockResponseOnce(JSON.stringify(expectedBody), {url, method: CachingClient.GET,
+                                                            headers:{
+                                                                'Last-modified': 'Mon, 13 July 2020 12:12:12 GMT',
+                                                                ETag: 'XXXXX',
+                                                            }})
+          .mockResponseOnce(null, {url, method: CachingClient.HEAD,
+                                    headers:{
+                                      'Last-modified': 'Mon, 14 July 2020 12:12:12 GMT',
+                                      ETag: 'XXXXX',
+                                    }})
+          .mockResponseOnce(JSON.stringify(expectedBody), {url, method: CachingClient.GET,
+                                                          headers:{
+                                                              'Last-modified': 'Mon, 14 July 2020 12:12:12 GMT',
+                                                              ETag: 'XXXXX',
+                                                          }});
+
+      // Make the request passing a callback to recieve event of cache update
+      const cacheUpdateHandler = jest.fn((event) => {
+                                          expect(event).not.toBeUndefined();
+                                          expect(event.detail).not.toBeUndefined();
+                                          expect(event.detail.url).toEqual(url);
+
+                                        });
+      const responseBody = await cachingClient.get(url, {json: true, callback: cacheUpdateHandler});
+
+      // Assert response body is correct
+      expect(responseBody).toEqual(expectedBody);
+
+      // Assert the cache entry for the request
+      expect(_caches['read-through-cache-v1']).not.toBeUndefined();
+      expect(_caches['read-through-cache-v1'][url]).not.toBeUndefined();
+
+      // Make the request again
+      const responseBodyCached = await cachingClient.get(url, {json: true});
+      // Assert response body is correct
+      expect(responseBodyCached).toEqual(expectedBody);
+      // Assert fetch has been called (one for the inital GET request, one for the HEAD to check
+      // the available cached response freshness and one to update the cached response).
+      expect(fetch).toHaveBeenCalled();
+      expect(fetch).toHaveBeenCalledTimes(3);
+      expect(cacheUpdateHandler).toHaveBeenCalled();
+      expect(cacheUpdateHandler).toHaveBeenCalledTimes(1);
+
+    });
+
+   it('Check GET request - envelop properties handling', async () => {
         const cachingClient = new CachingClient();    
         // Check the cache is clear
         expect(_caches['read-through-cache-v1']).toBeUndefined();

--- a/cachingClient/test/index.test.js
+++ b/cachingClient/test/index.test.js
@@ -43,7 +43,7 @@ describe('caching-client', () => {
         fetch.mockResponseOnce(JSON.stringify(expectedBody), {url});
         
         // Make the request
-        const responseBody = await cachingClient.get(url, true);
+        const responseBody = await cachingClient.get(url, {json: true});
 
         // Assert response body is correct
         expect(responseBody).toEqual(expectedBody);
@@ -52,6 +52,32 @@ describe('caching-client', () => {
         expect(_caches['read-through-cache-v1']).not.toBeUndefined();
         expect(_caches['read-through-cache-v1'][url]).not.toBeUndefined();
     });
+
+    it('Check GET request - return cached request', async () => {
+      const cachingClient = new CachingClient();    
+      // Check the cache is clear
+      expect(_caches['read-through-cache-v1']).toBeUndefined();
+
+      // Setup mock request
+      const url = 'https://mock.com/todo/1';
+      const expectedBody = [{'completed': false, 'id': 1, 'title': 'delectus aut autem', 'userId': 1}, {'completed': false, 'id': 2, 'title': 'quis ut nam facilis et officia qui', 'userId': 1}, {'completed': false, 'id': 3, 'title': 'fugiat veniam minus', 'userId': 1}, {'completed': true, 'id': 4, 'title': 'et porro tempora', 'userId': 1}, {'completed': false, 'id': 5, 'title': 'laboriosam mollitia et enim quasi adipisci quia provident illum', 'userId': 1}, {'completed': false, 'id': 6, 'title': 'qui ullam ratione quibusdam voluptatem quia omnis', 'userId': 1}, {'completed': false, 'id': 7, 'title': 'illo expedita consequatur quia in', 'userId': 1}, {'completed': true, 'id': 8, 'title': 'quo adipisci enim quam ut ab', 'userId': 1}, {'completed': false, 'id': 9, 'title': 'molestiae perspiciatis ipsa', 'userId': 1}, {'completed': true, 'id': 10, 'title': 'illo est ratione doloremque quia maiores aut', 'userId': 1}, {'completed': true, 'id': 11, 'title': 'vero rerum temporibus dolor', 'userId': 1}, {'completed': true, 'id': 12, 'title': 'ipsa repellendus fugit nisi', 'userId': 1}, {'completed': false, 'id': 13, 'title': 'et doloremque nulla', 'userId': 1}, {'completed': true, 'id': 14, 'title': 'repellendus sunt dolores architecto voluptatum', 'userId': 1}, {'completed': true, 'id': 15, 'title': 'ab voluptatum amet voluptas', 'userId': 1}, {'completed': true, 'id': 16, 'title': 'accusamus eos facilis sint et aut voluptatem', 'userId': 1}, {'completed': true, 'id': 17, 'title': 'quo laboriosam deleniti aut qui', 'userId': 1}, {'completed': false, 'id': 18, 'title': 'dolorum est consequatur ea mollitia in culpa', 'userId': 1}, {'completed': true, 'id': 19, 'title': 'molestiae ipsa aut voluptatibus pariatur dolor nihil', 'userId': 1}, {'completed': true, 'id': 20, 'title': 'ullam nobis libero sapiente ad optio sint', 'userId': 1}];
+      fetch.mockResponseOnce(JSON.stringify(expectedBody), {url});
+      
+      // Make the request
+      const responseBody = await cachingClient.get(url, {json: true});
+
+      // Assert response body is correct
+      expect(responseBody).toEqual(expectedBody);
+
+      // Assert the cache entry for the request
+      expect(_caches['read-through-cache-v1']).not.toBeUndefined();
+      expect(_caches['read-through-cache-v1'][url]).not.toBeUndefined();
+
+      // Make the request again
+      const responseBodyCached = await cachingClient.get(url, {json: true});
+      // Assert response body is correct
+      expect(responseBody).toEqual(expectedBody);
+  });
 
    it('Check envelop properties handling', async () => {
         const cachingClient = new CachingClient();    
@@ -115,7 +141,7 @@ describe('caching-client', () => {
                 JSON.stringify(schemaBody), {url});
 
         // Make the request
-        const responseBody = await cachingClient.get(url, true);
+        const responseBody = await cachingClient.get(url, {json: true});
 
         // Assert response body is correct
         expect(responseBody).toEqual(expectedBody);

--- a/scrud-nuxt/package-lock.json
+++ b/scrud-nuxt/package-lock.json
@@ -4046,6 +4046,6362 @@
         }
       }
     },
+    "caching-client": {
+      "version": "file:../cachingClient",
+      "dependencies": {
+        "@babel/cli": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.10.5.tgz",
+          "integrity": "sha512-j9H9qSf3kLdM0Ao3aGPbGZ73mEA9XazuupcS6cDGWuiyAcANoguhP0r2Lx32H5JGw4sSSoHG3x/mxVnHgvOoyA==",
+          "requires": {
+            "chokidar": "^2.1.8",
+            "commander": "^4.0.1",
+            "convert-source-map": "^1.1.0",
+            "fs-readdir-recursive": "^1.1.0",
+            "glob": "^7.0.0",
+            "lodash": "^4.17.19",
+            "make-dir": "^2.1.0",
+            "slash": "^2.0.0",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "make-dir": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+              "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+              "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+              }
+            },
+            "pify": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+            },
+            "slash": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+              "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            }
+          }
+        },
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/compat-data": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.10.5.tgz",
+          "integrity": "sha512-mPVoWNzIpYJHbWje0if7Ck36bpbtTvIxOi9+6WSK9wjGEXearAqlwBoTQvVjsAY2VIwgcs8V940geY3okzRCEw==",
+          "requires": {
+            "browserslist": "^4.12.0",
+            "invariant": "^2.2.4",
+            "semver": "^5.5.0"
+          }
+        },
+        "@babel/core": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.0.tgz",
+          "integrity": "sha512-mkLq8nwaXmDtFmRkQ8ED/eA2CnVw4zr7dCztKalZXBvdK5EeNUAesrrwUqjQEzFgomJssayzB0aqlOsP1vGLqg==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.11.0",
+            "@babel/helper-module-transforms": "^7.11.0",
+            "@babel/helpers": "^7.10.4",
+            "@babel/parser": "^7.11.0",
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.11.0",
+            "@babel/types": "^7.11.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.1",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.19",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "@babel/generator": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+              "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+              "requires": {
+                "@babel/types": "^7.11.0",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+              }
+            },
+            "@babel/helper-module-transforms": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+              "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+              "requires": {
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.11.0",
+                "lodash": "^4.17.19"
+              }
+            },
+            "@babel/helper-split-export-declaration": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+              "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+              "requires": {
+                "@babel/types": "^7.11.0"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
+              "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw=="
+            },
+            "@babel/traverse": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+              "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+              "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.11.0",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/parser": "^7.11.0",
+                "@babel/types": "^7.11.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.19"
+              }
+            },
+            "@babel/types": {
+              "version": "7.11.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+              "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            }
+          }
+        },
+        "@babel/generator": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
+          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+          "requires": {
+            "@babel/types": "^7.10.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "2.5.2",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+              "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            }
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+          "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+          "integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+          "requires": {
+            "@babel/helper-explode-assignable-expression": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-compilation-targets": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
+          "integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
+          "requires": {
+            "@babel/compat-data": "^7.10.4",
+            "browserslist": "^4.12.0",
+            "invariant": "^2.2.4",
+            "levenary": "^1.1.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+          "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-member-expression-to-functions": "^7.10.5",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4"
+          }
+        },
+        "@babel/helper-create-regexp-features-plugin": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
+          "integrity": "sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==",
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.10.4",
+            "@babel/helper-regex": "^7.10.4",
+            "regexpu-core": "^4.7.0"
+          }
+        },
+        "@babel/helper-define-map": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+          "integrity": "sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==",
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/types": "^7.10.5",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/helper-explode-assignable-expression": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
+          "integrity": "sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==",
+          "requires": {
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+          "integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
+          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
+          "requires": {
+            "@babel/types": "^7.10.5"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
+          "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-simple-access": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.5",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
+        },
+        "@babel/helper-regex": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+          "integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
+          "requires": {
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/helper-remap-async-to-generator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
+          "integrity": "sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==",
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.10.4",
+            "@babel/helper-wrap-function": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+          "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.10.4",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+          "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+          "requires": {
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+          "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+        },
+        "@babel/helper-wrap-function": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
+          "integrity": "sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==",
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+          "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+          "requires": {
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
+          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+          "integrity": "sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-remap-async-to-generator": "^7.10.4",
+            "@babel/plugin-syntax-async-generators": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-class-properties": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
+          "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-proposal-dynamic-import": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
+          "integrity": "sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-json-strings": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
+          "integrity": "sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-json-strings": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-nullish-coalescing-operator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
+          "integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-numeric-separator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
+          "integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+          }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
+          "integrity": "sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+            "@babel/plugin-transform-parameters": "^7.10.4"
+          }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
+          "integrity": "sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.4.tgz",
+          "integrity": "sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-private-methods": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz",
+          "integrity": "sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==",
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
+          "integrity": "sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==",
+          "requires": {
+            "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-syntax-async-generators": {
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+          "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+          }
+        },
+        "@babel/plugin-syntax-bigint": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+          "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+          }
+        },
+        "@babel/plugin-syntax-class-properties": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+          "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-syntax-dynamic-import": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+          "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+          }
+        },
+        "@babel/plugin-syntax-import-meta": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+          "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-syntax-json-strings": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+          "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+          }
+        },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+          "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+          "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+          }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+          "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+          "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+          }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+          "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+          }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+          "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.8.0"
+          }
+        },
+        "@babel/plugin-syntax-top-level-await": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
+          "integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
+          "integrity": "sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
+          "integrity": "sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==",
+          "requires": {
+            "@babel/helper-module-imports": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-remap-async-to-generator": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
+          "integrity": "sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-block-scoping": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz",
+          "integrity": "sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
+          "integrity": "sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==",
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.10.4",
+            "@babel/helper-define-map": "^7.10.4",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4",
+            "globals": "^11.1.0"
+          },
+          "dependencies": {
+            "globals": {
+              "version": "11.12.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+              "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+            }
+          }
+        },
+        "@babel/plugin-transform-computed-properties": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
+          "integrity": "sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-destructuring": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
+          "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
+          "integrity": "sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==",
+          "requires": {
+            "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
+          "integrity": "sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
+          "integrity": "sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==",
+          "requires": {
+            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-for-of": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
+          "integrity": "sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
+          "integrity": "sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==",
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-literals": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
+          "integrity": "sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-member-expression-literals": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
+          "integrity": "sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+          "integrity": "sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==",
+          "requires": {
+            "@babel/helper-module-transforms": "^7.10.5",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "babel-plugin-dynamic-import-node": "^2.3.3"
+          }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
+          "integrity": "sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==",
+          "requires": {
+            "@babel/helper-module-transforms": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-simple-access": "^7.10.4",
+            "babel-plugin-dynamic-import-node": "^2.3.3"
+          }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
+          "integrity": "sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==",
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.10.4",
+            "@babel/helper-module-transforms": "^7.10.5",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "babel-plugin-dynamic-import-node": "^2.3.3"
+          }
+        },
+        "@babel/plugin-transform-modules-umd": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
+          "integrity": "sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==",
+          "requires": {
+            "@babel/helper-module-transforms": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
+          "integrity": "sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==",
+          "requires": {
+            "@babel/helper-create-regexp-features-plugin": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-new-target": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
+          "integrity": "sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-object-super": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
+          "integrity": "sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+          "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-property-literals": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
+          "integrity": "sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-regenerator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
+          "integrity": "sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==",
+          "requires": {
+            "regenerator-transform": "^0.14.2"
+          }
+        },
+        "@babel/plugin-transform-reserved-words": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
+          "integrity": "sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
+          "integrity": "sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-spread": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.4.tgz",
+          "integrity": "sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
+          "integrity": "sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-regex": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-template-literals": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+          "integrity": "sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==",
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
+          "integrity": "sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-unicode-escapes": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
+          "integrity": "sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
+          "integrity": "sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==",
+          "requires": {
+            "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/preset-env": {
+          "version": "7.10.4",
+          "integrity": "sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==",
+          "requires": {
+            "@babel/compat-data": "^7.10.4",
+            "@babel/helper-compilation-targets": "^7.10.4",
+            "@babel/helper-module-imports": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
+            "@babel/plugin-proposal-class-properties": "^7.10.4",
+            "@babel/plugin-proposal-dynamic-import": "^7.10.4",
+            "@babel/plugin-proposal-json-strings": "^7.10.4",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+            "@babel/plugin-proposal-numeric-separator": "^7.10.4",
+            "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
+            "@babel/plugin-proposal-optional-chaining": "^7.10.4",
+            "@babel/plugin-proposal-private-methods": "^7.10.4",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
+            "@babel/plugin-syntax-async-generators": "^7.8.0",
+            "@babel/plugin-syntax-class-properties": "^7.10.4",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+            "@babel/plugin-syntax-json-strings": "^7.8.0",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+            "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+            "@babel/plugin-syntax-top-level-await": "^7.10.4",
+            "@babel/plugin-transform-arrow-functions": "^7.10.4",
+            "@babel/plugin-transform-async-to-generator": "^7.10.4",
+            "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
+            "@babel/plugin-transform-block-scoping": "^7.10.4",
+            "@babel/plugin-transform-classes": "^7.10.4",
+            "@babel/plugin-transform-computed-properties": "^7.10.4",
+            "@babel/plugin-transform-destructuring": "^7.10.4",
+            "@babel/plugin-transform-dotall-regex": "^7.10.4",
+            "@babel/plugin-transform-duplicate-keys": "^7.10.4",
+            "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
+            "@babel/plugin-transform-for-of": "^7.10.4",
+            "@babel/plugin-transform-function-name": "^7.10.4",
+            "@babel/plugin-transform-literals": "^7.10.4",
+            "@babel/plugin-transform-member-expression-literals": "^7.10.4",
+            "@babel/plugin-transform-modules-amd": "^7.10.4",
+            "@babel/plugin-transform-modules-commonjs": "^7.10.4",
+            "@babel/plugin-transform-modules-systemjs": "^7.10.4",
+            "@babel/plugin-transform-modules-umd": "^7.10.4",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
+            "@babel/plugin-transform-new-target": "^7.10.4",
+            "@babel/plugin-transform-object-super": "^7.10.4",
+            "@babel/plugin-transform-parameters": "^7.10.4",
+            "@babel/plugin-transform-property-literals": "^7.10.4",
+            "@babel/plugin-transform-regenerator": "^7.10.4",
+            "@babel/plugin-transform-reserved-words": "^7.10.4",
+            "@babel/plugin-transform-shorthand-properties": "^7.10.4",
+            "@babel/plugin-transform-spread": "^7.10.4",
+            "@babel/plugin-transform-sticky-regex": "^7.10.4",
+            "@babel/plugin-transform-template-literals": "^7.10.4",
+            "@babel/plugin-transform-typeof-symbol": "^7.10.4",
+            "@babel/plugin-transform-unicode-escapes": "^7.10.4",
+            "@babel/plugin-transform-unicode-regex": "^7.10.4",
+            "@babel/preset-modules": "^0.1.3",
+            "@babel/types": "^7.10.4",
+            "browserslist": "^4.12.0",
+            "core-js-compat": "^3.6.2",
+            "invariant": "^2.2.2",
+            "levenary": "^1.1.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "@babel/preset-modules": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
+          "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+            "@babel/plugin-transform-dotall-regex": "^7.4.4",
+            "@babel/types": "^7.4.4",
+            "esutils": "^2.0.2"
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
+          "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.13.7",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+              "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+            }
+          }
+        },
+        "@babel/template": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
+          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.10.5",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4",
+            "@babel/parser": "^7.10.5",
+            "@babel/types": "^7.10.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "globals": {
+              "version": "11.12.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+              "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
+          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          },
+          "dependencies": {
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+              "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+            }
+          }
+        },
+        "@bcoe/v8-coverage": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+          "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+        },
+        "@cnakazawa/watch": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+          "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
+          "requires": {
+            "exec-sh": "^0.3.2",
+            "minimist": "^1.2.0"
+          }
+        },
+        "@istanbuljs/load-nyc-config": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+          "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+          "requires": {
+            "camelcase": "^5.3.1",
+            "find-up": "^4.1.0",
+            "get-package-type": "^0.1.0",
+            "js-yaml": "^3.13.1",
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "@istanbuljs/schema": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+          "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw=="
+        },
+        "@jest/console": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.1.0.tgz",
+          "integrity": "sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/core": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.1.0.tgz",
+          "integrity": "sha512-zyizYmDJOOVke4OO/De//aiv8b07OwZzL2cfsvWF3q9YssfpcKfcnZAwDY8f+A76xXSMMYe8i/f/LPocLlByfw==",
+          "requires": {
+            "@jest/console": "^26.1.0",
+            "@jest/reporters": "^26.1.0",
+            "@jest/test-result": "^26.1.0",
+            "@jest/transform": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-changed-files": "^26.1.0",
+            "jest-config": "^26.1.0",
+            "jest-haste-map": "^26.1.0",
+            "jest-message-util": "^26.1.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-resolve": "^26.1.0",
+            "jest-resolve-dependencies": "^26.1.0",
+            "jest-runner": "^26.1.0",
+            "jest-runtime": "^26.1.0",
+            "jest-snapshot": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "jest-validate": "^26.1.0",
+            "jest-watcher": "^26.1.0",
+            "micromatch": "^4.0.2",
+            "p-each-series": "^2.1.0",
+            "rimraf": "^3.0.0",
+            "slash": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.1.0.tgz",
+          "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
+          "requires": {
+            "@jest/fake-timers": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "jest-mock": "^26.1.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.1.0.tgz",
+          "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "jest-message-util": "^26.1.0",
+            "jest-mock": "^26.1.0",
+            "jest-util": "^26.1.0"
+          }
+        },
+        "@jest/globals": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.1.0.tgz",
+          "integrity": "sha512-MKiHPNaT+ZoG85oMaYUmGHEqu98y3WO2yeIDJrs2sJqHhYOy3Z6F7F/luzFomRQ8SQ1wEkmahFAz2291Iv8EAw==",
+          "requires": {
+            "@jest/environment": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "expect": "^26.1.0"
+          }
+        },
+        "@jest/reporters": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.1.0.tgz",
+          "integrity": "sha512-SVAysur9FOIojJbF4wLP0TybmqwDkdnFxHSPzHMMIYyBtldCW9gG+Q5xWjpMFyErDiwlRuPyMSJSU64A67Pazg==",
+          "requires": {
+            "@bcoe/v8-coverage": "^0.2.3",
+            "@jest/console": "^26.1.0",
+            "@jest/test-result": "^26.1.0",
+            "@jest/transform": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.2.4",
+            "istanbul-lib-coverage": "^3.0.0",
+            "istanbul-lib-instrument": "^4.0.3",
+            "istanbul-lib-report": "^3.0.0",
+            "istanbul-lib-source-maps": "^4.0.0",
+            "istanbul-reports": "^3.0.2",
+            "jest-haste-map": "^26.1.0",
+            "jest-resolve": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "jest-worker": "^26.1.0",
+            "node-notifier": "^7.0.0",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.0",
+            "string-length": "^4.0.1",
+            "terminal-link": "^2.0.0",
+            "v8-to-istanbul": "^4.1.3"
+          }
+        },
+        "@jest/source-map": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.1.0.tgz",
+          "integrity": "sha512-XYRPYx4eEVX15cMT9mstnO7hkHP3krNtKfxUYd8L7gbtia8JvZZ6bMzSwa6IQJENbudTwKMw5R1BePRD+bkEmA==",
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.4",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.1.0.tgz",
+          "integrity": "sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==",
+          "requires": {
+            "@jest/console": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.1.0.tgz",
+          "integrity": "sha512-Z/hcK+rTq56E6sBwMoQhSRDVjqrGtj1y14e2bIgcowARaIE1SgOanwx6gvY4Q9gTKMoZQXbXvptji+q5GYxa6Q==",
+          "requires": {
+            "@jest/test-result": "^26.1.0",
+            "graceful-fs": "^4.2.4",
+            "jest-haste-map": "^26.1.0",
+            "jest-runner": "^26.1.0",
+            "jest-runtime": "^26.1.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.1.0.tgz",
+          "integrity": "sha512-ICPm6sUXmZJieq45ix28k0s+d/z2E8CHDsq+WwtWI6kW8m7I8kPqarSEcUN86entHQ570ZBRci5OWaKL0wlAWw==",
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^26.1.0",
+            "babel-plugin-istanbul": "^6.0.0",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-haste-map": "^26.1.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-util": "^26.1.0",
+            "micromatch": "^4.0.2",
+            "pirates": "^4.0.1",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "^3.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@sinonjs/commons": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+          "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/fake-timers": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+          "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        },
+        "@types/babel__core": {
+          "version": "7.1.9",
+          "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
+          "integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+          "requires": {
+            "@babel/parser": "^7.1.0",
+            "@babel/types": "^7.0.0",
+            "@types/babel__generator": "*",
+            "@types/babel__template": "*",
+            "@types/babel__traverse": "*"
+          }
+        },
+        "@types/babel__generator": {
+          "version": "7.6.1",
+          "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+          "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@types/babel__template": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+          "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+          "requires": {
+            "@babel/parser": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@types/babel__traverse": {
+          "version": "7.0.13",
+          "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
+          "integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
+          "requires": {
+            "@babel/types": "^7.3.0"
+          }
+        },
+        "@types/color-name": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+        },
+        "@types/graceful-fs": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+          "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/istanbul-lib-coverage": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+          "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+        },
+        "@types/istanbul-lib-report": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+          "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "*"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "*",
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/node": {
+          "version": "14.0.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.24.tgz",
+          "integrity": "sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA=="
+        },
+        "@types/normalize-package-data": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
+        },
+        "@types/prettier": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
+          "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA=="
+        },
+        "@types/stack-utils": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+          "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "@types/yargs-parser": {
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+          "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
+        },
+        "abab": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+          "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg=="
+        },
+        "acorn": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+          "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
+        },
+        "acorn-globals": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+          "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+          "requires": {
+            "acorn": "^6.0.1",
+            "acorn-walk": "^6.0.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+              "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+            },
+            "acorn-walk": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+              "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+            }
+          }
+        },
+        "acorn-walk": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
+        },
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-escapes": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+          "requires": {
+            "type-fest": "^0.11.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.11.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+              "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
+            }
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+          "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
+        "async-each": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+          "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+          "optional": true
+        },
+        "async-limiter": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+          "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "atob": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+          "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "aws4": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+          "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+        },
+        "babel-jest": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.1.0.tgz",
+          "integrity": "sha512-Nkqgtfe7j6PxLO6TnCQQlkMm8wdTdnIF8xrdpooHCuD5hXRzVEPbPneTJKknH5Dsv3L8ip9unHDAp48YQ54Dkg==",
+          "requires": {
+            "@jest/transform": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "@types/babel__core": "^7.1.7",
+            "babel-plugin-istanbul": "^6.0.0",
+            "babel-preset-jest": "^26.1.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "slash": "^3.0.0"
+          }
+        },
+        "babel-plugin-dynamic-import-node": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+          "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+          "requires": {
+            "object.assign": "^4.1.0"
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+          "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@istanbuljs/load-nyc-config": "^1.0.0",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-instrument": "^4.0.0",
+            "test-exclude": "^6.0.0"
+          }
+        },
+        "babel-plugin-jest-hoist": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.1.0.tgz",
+          "integrity": "sha512-qhqLVkkSlqmC83bdMhM8WW4Z9tB+JkjqAqlbbohS9sJLT5Ha2vfzuKqg5yenXrAjOPG2YC0WiXdH3a9PvB+YYw==",
+          "requires": {
+            "@babel/template": "^7.3.3",
+            "@babel/types": "^7.3.3",
+            "@types/babel__core": "^7.0.0",
+            "@types/babel__traverse": "^7.0.6"
+          }
+        },
+        "babel-preset-current-node-syntax": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
+          "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+          "requires": {
+            "@babel/plugin-syntax-async-generators": "^7.8.4",
+            "@babel/plugin-syntax-bigint": "^7.8.3",
+            "@babel/plugin-syntax-class-properties": "^7.8.3",
+            "@babel/plugin-syntax-import-meta": "^7.8.3",
+            "@babel/plugin-syntax-json-strings": "^7.8.3",
+            "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+            "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+          }
+        },
+        "babel-preset-jest": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.1.0.tgz",
+          "integrity": "sha512-na9qCqFksknlEj5iSdw1ehMVR06LCCTkZLGKeEtxDDdhg8xpUF09m29Kvh1pRbZ07h7AQ5ttLYUwpXL4tO6w7w==",
+          "requires": {
+            "babel-plugin-jest-hoist": "^26.1.0",
+            "babel-preset-current-node-syntax": "^0.1.2"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base": {
+          "version": "0.11.2",
+          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "optional": true
+        },
+        "bindings": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+          "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+          "optional": true,
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "browser-env": {
+          "version": "3.3.0",
+          "integrity": "sha512-XO+rbi2f9DtuoYgnN/Um80Qz/m033C3fKdUxKbbNs+jCshezRENMlG+QGT9qZyZE4b/KYTwUu6RNMCavGhPdEQ==",
+          "requires": {
+            "window": "4.2.6"
+          }
+        },
+        "browser-process-hrtime": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+          "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+        },
+        "browserslist": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.13.0.tgz",
+          "integrity": "sha512-MINatJ5ZNrLnQ6blGvePd/QOz9Xtu+Ne+x29iQSCHfkU5BugKVJwZKn/iiL8UbpIpa3JhviKjz+XxMo0m2caFQ==",
+          "requires": {
+            "caniuse-lite": "^1.0.30001093",
+            "electron-to-chromium": "^1.3.488",
+            "escalade": "^3.0.1",
+            "node-releases": "^1.1.58"
+          }
+        },
+        "bser": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+          "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+          "requires": {
+            "node-int64": "^0.4.0"
+          }
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001105",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001105.tgz",
+          "integrity": "sha512-JupOe6+dGMr7E20siZHIZQwYqrllxotAhiaej96y6x00b/48rPt42o+SzOSCPbrpsDWvRja40Hwrj0g0q6LZJg=="
+        },
+        "capture-exit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+          "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+          "requires": {
+            "rsvp": "^4.8.4"
+          }
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "char-regex": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+          "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          },
+          "dependencies": {
+            "anymatch": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+              "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+              "optional": true,
+              "requires": {
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+              },
+              "dependencies": {
+                "normalize-path": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                  "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                  "optional": true,
+                  "requires": {
+                    "remove-trailing-separator": "^1.0.1"
+                  }
+                }
+              }
+            },
+            "braces": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+              "optional": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "optional": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "optional": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "optional": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "optional": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "optional": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "optional": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            },
+            "to-regex-range": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+              "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+              "optional": true,
+              "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+              }
+            }
+          }
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "co": {
+          "version": "4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+        },
+        "collect-v8-coverage": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+          "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg=="
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+        },
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "convert-source-map": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "core-js-compat": {
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
+          "integrity": "sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==",
+          "requires": {
+            "browserslist": "^4.8.5",
+            "semver": "7.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+              "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
+            }
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cross-fetch": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
+          "integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+          "requires": {
+            "node-fetch": "2.6.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "which": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+              "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            }
+          }
+        },
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+        },
+        "cssstyle": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+          "integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+          "requires": {
+            "cssom": "0.3.x"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "data-urls": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+          "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+          "requires": {
+            "abab": "^2.0.0",
+            "whatwg-mimetype": "^2.2.0",
+            "whatwg-url": "^7.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "decimal.js": {
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+          "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+          "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+        },
+        "deepmerge": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "detect-newline": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+          "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
+        },
+        "diff-sequences": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
+          "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg=="
+        },
+        "domexception": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+          "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+          "requires": {
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.504",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.504.tgz",
+          "integrity": "sha512-yOXnuPaaLAIZUVuXHYDCo3EeaiEfbFgYWCPH1tBMp+jznCq/zQYKnf6HmkKBmLJ0VES81avl18JZO1lx/XAHOw=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "end-of-stream": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+          "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+          "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "escalade": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
+          "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "escodegen": {
+          "version": "1.14.3",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+          "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+        },
+        "esutils": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+          "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+        },
+        "exec-sh": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
+          "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A=="
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+          "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "expect": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.1.0.tgz",
+          "integrity": "sha512-QbH4LZXDsno9AACrN9eM0zfnby9G+OsdNgZUohjg/P0mLy1O+/bzTAJGT6VSIjVCe8yKM6SzEl/ckEOFBT7Vnw==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.0.0",
+            "jest-matcher-utils": "^26.1.0",
+            "jest-message-util": "^26.1.0",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+          "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+        },
+        "fb-watchman": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+          "integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
+          "requires": {
+            "bser": "2.1.1"
+          }
+        },
+        "file-uri-to-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+          "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+          "optional": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "fs-readdir-recursive": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+          "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "optional": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "gensync": {
+          "version": "1.0.0-beta.1",
+          "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+          "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "get-package-type": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+          "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+        },
+        "growly": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+          "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+          "optional": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+          "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+          "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+          "requires": {
+            "whatwg-encoding": "^1.0.1"
+          }
+        },
+        "html-escaper": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+          "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "human-signals": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "import-local": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+          "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+          "requires": {
+            "pkg-dir": "^4.2.0",
+            "resolve-cwd": "^3.0.0"
+          }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "ip-regex": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+          "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            }
+          }
+        },
+        "is-docker": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
+          "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
+          "optional": true
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "is-generator-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+          "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "optional": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-potential-custom-element-name": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+          "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c="
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-symbol": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+          "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+        },
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "optional": true,
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "istanbul-lib-coverage": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+          "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg=="
+        },
+        "istanbul-lib-instrument": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+          "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+          "requires": {
+            "@babel/core": "^7.7.5",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+          "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+          "requires": {
+            "istanbul-lib-coverage": "^3.0.0",
+            "make-dir": "^3.0.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+          "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+          "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^3.0.0",
+            "source-map": "^0.6.1"
+          }
+        },
+        "istanbul-reports": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+          "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+          "requires": {
+            "html-escaper": "^2.0.0",
+            "istanbul-lib-report": "^3.0.0"
+          }
+        },
+        "jest": {
+          "version": "26.1.0",
+          "integrity": "sha512-LIti8jppw5BcQvmNJe4w2g1N/3V68HUfAv9zDVm7v+VAtQulGhH0LnmmiVkbNE4M4I43Bj2fXPiBGKt26k9tHw==",
+          "requires": {
+            "@jest/core": "^26.1.0",
+            "import-local": "^3.0.2",
+            "jest-cli": "^26.1.0"
+          },
+          "dependencies": {
+            "jest-cli": {
+              "version": "26.1.0",
+              "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.1.0.tgz",
+              "integrity": "sha512-Imumvjgi3rU7stq6SJ1JUEMaV5aAgJYXIs0jPqdUnF47N/Tk83EXfmtvNKQ+SnFVI6t6mDOvfM3aA9Sg6kQPSw==",
+              "requires": {
+                "@jest/core": "^26.1.0",
+                "@jest/test-result": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "import-local": "^3.0.2",
+                "is-ci": "^2.0.0",
+                "jest-config": "^26.1.0",
+                "jest-util": "^26.1.0",
+                "jest-validate": "^26.1.0",
+                "prompts": "^2.0.1",
+                "yargs": "^15.3.1"
+              }
+            }
+          }
+        },
+        "jest-changed-files": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.1.0.tgz",
+          "integrity": "sha512-HS5MIJp3B8t0NRKGMCZkcDUZo36mVRvrDETl81aqljT1S9tqiHRSpyoOvWg9ZilzZG9TDisDNaN1IXm54fLRZw==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "execa": "^4.0.0",
+            "throat": "^5.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "7.0.3",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+              "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+              "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+              }
+            },
+            "execa": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+              "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+              "requires": {
+                "cross-spawn": "^7.0.0",
+                "get-stream": "^5.0.0",
+                "human-signals": "^1.1.1",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.0",
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2",
+                "strip-final-newline": "^2.0.0"
+              }
+            },
+            "get-stream": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+              "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            },
+            "is-stream": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+              "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+            },
+            "npm-run-path": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+              "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+              "requires": {
+                "path-key": "^3.0.0"
+              }
+            },
+            "path-key": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+              "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+            },
+            "shebang-command": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+              "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+              "requires": {
+                "shebang-regex": "^3.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+              "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+            }
+          }
+        },
+        "jest-config": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.1.0.tgz",
+          "integrity": "sha512-ONTGeoMbAwGCdq4WuKkMcdMoyfs5CLzHEkzFOlVvcDXufZSaIWh/OXMLa2fwKXiOaFcqEw8qFr4VOKJQfn4CVw==",
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/test-sequencer": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "babel-jest": "^26.1.0",
+            "chalk": "^4.0.0",
+            "deepmerge": "^4.2.2",
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.2.4",
+            "jest-environment-jsdom": "^26.1.0",
+            "jest-environment-node": "^26.1.0",
+            "jest-get-type": "^26.0.0",
+            "jest-jasmine2": "^26.1.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-resolve": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "jest-validate": "^26.1.0",
+            "micromatch": "^4.0.2",
+            "pretty-format": "^26.1.0"
+          }
+        },
+        "jest-diff": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.1.0.tgz",
+          "integrity": "sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==",
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.0.0",
+            "jest-get-type": "^26.0.0",
+            "pretty-format": "^26.1.0"
+          }
+        },
+        "jest-docblock": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+          "integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+          "requires": {
+            "detect-newline": "^3.0.0"
+          }
+        },
+        "jest-each": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.1.0.tgz",
+          "integrity": "sha512-lYiSo4Igr81q6QRsVQq9LIkJW0hZcKxkIkHzNeTMPENYYDw/W/Raq28iJ0sLlNFYz2qxxeLnc5K2gQoFYlu2bA==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^26.0.0",
+            "jest-util": "^26.1.0",
+            "pretty-format": "^26.1.0"
+          }
+        },
+        "jest-environment-jsdom": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.1.0.tgz",
+          "integrity": "sha512-dWfiJ+spunVAwzXbdVqPH1LbuJW/kDL+FyqgA5YzquisHqTi0g9hquKif9xKm7c1bKBj6wbmJuDkeMCnxZEpUw==",
+          "requires": {
+            "@jest/environment": "^26.1.0",
+            "@jest/fake-timers": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "jest-mock": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "jsdom": "^16.2.2"
+          },
+          "dependencies": {
+            "acorn-globals": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+              "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+              "requires": {
+                "acorn": "^7.1.1",
+                "acorn-walk": "^7.1.1"
+              }
+            },
+            "cssom": {
+              "version": "0.4.4",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+              "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+            },
+            "cssstyle": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+              "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+              "requires": {
+                "cssom": "~0.3.6"
+              },
+              "dependencies": {
+                "cssom": {
+                  "version": "0.3.8",
+                  "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+                  "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+                }
+              }
+            },
+            "data-urls": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+              "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+              "requires": {
+                "abab": "^2.0.3",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0"
+              }
+            },
+            "domexception": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+              "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+              "requires": {
+                "webidl-conversions": "^5.0.0"
+              },
+              "dependencies": {
+                "webidl-conversions": {
+                  "version": "5.0.0",
+                  "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+                  "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+                }
+              }
+            },
+            "html-encoding-sniffer": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+              "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+              "requires": {
+                "whatwg-encoding": "^1.0.5"
+              }
+            },
+            "jsdom": {
+              "version": "16.3.0",
+              "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.3.0.tgz",
+              "integrity": "sha512-zggeX5UuEknpdZzv15+MS1dPYG0J/TftiiNunOeNxSl3qr8Z6cIlQpN0IdJa44z9aFxZRIVqRncvEhQ7X5DtZg==",
+              "requires": {
+                "abab": "^2.0.3",
+                "acorn": "^7.1.1",
+                "acorn-globals": "^6.0.0",
+                "cssom": "^0.4.4",
+                "cssstyle": "^2.2.0",
+                "data-urls": "^2.0.0",
+                "decimal.js": "^10.2.0",
+                "domexception": "^2.0.1",
+                "escodegen": "^1.14.1",
+                "html-encoding-sniffer": "^2.0.1",
+                "is-potential-custom-element-name": "^1.0.0",
+                "nwsapi": "^2.2.0",
+                "parse5": "5.1.1",
+                "request": "^2.88.2",
+                "request-promise-native": "^1.0.8",
+                "saxes": "^5.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^3.0.1",
+                "w3c-hr-time": "^1.0.2",
+                "w3c-xmlserializer": "^2.0.0",
+                "webidl-conversions": "^6.1.0",
+                "whatwg-encoding": "^1.0.5",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0",
+                "ws": "^7.2.3",
+                "xml-name-validator": "^3.0.0"
+              }
+            },
+            "parse5": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+              "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+            },
+            "saxes": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+              "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+              "requires": {
+                "xmlchars": "^2.2.0"
+              }
+            },
+            "tough-cookie": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+              "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+              "requires": {
+                "ip-regex": "^2.1.0",
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+              }
+            },
+            "tr46": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+              "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+              "requires": {
+                "punycode": "^2.1.1"
+              }
+            },
+            "w3c-xmlserializer": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+              "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+              "requires": {
+                "xml-name-validator": "^3.0.0"
+              }
+            },
+            "webidl-conversions": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+              "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+            },
+            "whatwg-url": {
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
+              "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
+              "requires": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^2.0.2",
+                "webidl-conversions": "^5.0.0"
+              },
+              "dependencies": {
+                "webidl-conversions": {
+                  "version": "5.0.0",
+                  "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+                  "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+                }
+              }
+            },
+            "ws": {
+              "version": "7.3.1",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+              "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+            }
+          }
+        },
+        "jest-environment-jsdom-fourteen": {
+          "version": "1.0.1",
+          "integrity": "sha512-DojMX1sY+at5Ep+O9yME34CdidZnO3/zfPh8UW+918C5fIZET5vCjfkegixmsi7AtdYfkr4bPlIzmWnlvQkP7Q==",
+          "requires": {
+            "@jest/environment": "^24.3.0",
+            "@jest/fake-timers": "^24.3.0",
+            "@jest/types": "^24.3.0",
+            "jest-mock": "^24.0.0",
+            "jest-util": "^24.0.0",
+            "jsdom": "^14.1.0"
+          },
+          "dependencies": {
+            "@jest/console": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+              "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+              "requires": {
+                "@jest/source-map": "^24.9.0",
+                "chalk": "^2.0.1",
+                "slash": "^2.0.0"
+              }
+            },
+            "@jest/environment": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
+              "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+              "requires": {
+                "@jest/fake-timers": "^24.9.0",
+                "@jest/transform": "^24.9.0",
+                "@jest/types": "^24.9.0",
+                "jest-mock": "^24.9.0"
+              }
+            },
+            "@jest/fake-timers": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+              "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+              "requires": {
+                "@jest/types": "^24.9.0",
+                "jest-message-util": "^24.9.0",
+                "jest-mock": "^24.9.0"
+              }
+            },
+            "@jest/source-map": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+              "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+              "requires": {
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.1.15",
+                "source-map": "^0.6.0"
+              }
+            },
+            "@jest/test-result": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+              "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+              "requires": {
+                "@jest/console": "^24.9.0",
+                "@jest/types": "^24.9.0",
+                "@types/istanbul-lib-coverage": "^2.0.0"
+              }
+            },
+            "@jest/transform": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
+              "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+              "requires": {
+                "@babel/core": "^7.1.0",
+                "@jest/types": "^24.9.0",
+                "babel-plugin-istanbul": "^5.1.0",
+                "chalk": "^2.0.1",
+                "convert-source-map": "^1.4.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graceful-fs": "^4.1.15",
+                "jest-haste-map": "^24.9.0",
+                "jest-regex-util": "^24.9.0",
+                "jest-util": "^24.9.0",
+                "micromatch": "^3.1.10",
+                "pirates": "^4.0.1",
+                "realpath-native": "^1.1.0",
+                "slash": "^2.0.0",
+                "source-map": "^0.6.1",
+                "write-file-atomic": "2.4.1"
+              }
+            },
+            "@jest/types": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+              "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+              "requires": {
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^1.1.1",
+                "@types/yargs": "^13.0.0"
+              }
+            },
+            "@types/yargs": {
+              "version": "13.0.9",
+              "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
+              "integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
+              "requires": {
+                "@types/yargs-parser": "*"
+              }
+            },
+            "acorn": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+              "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "anymatch": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+              "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+              "requires": {
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+              }
+            },
+            "babel-plugin-istanbul": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+              "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+              "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "find-up": "^3.0.0",
+                "istanbul-lib-instrument": "^3.3.0",
+                "test-exclude": "^5.2.3"
+              }
+            },
+            "braces": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "fsevents": {
+              "version": "1.2.13",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+              "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+              "optional": true,
+              "requires": {
+                "bindings": "^1.5.0",
+                "nan": "^2.12.1"
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "istanbul-lib-coverage": {
+              "version": "2.0.5",
+              "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+              "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA=="
+            },
+            "istanbul-lib-instrument": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+              "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+              "requires": {
+                "@babel/generator": "^7.4.0",
+                "@babel/parser": "^7.4.3",
+                "@babel/template": "^7.4.0",
+                "@babel/traverse": "^7.4.3",
+                "@babel/types": "^7.4.0",
+                "istanbul-lib-coverage": "^2.0.5",
+                "semver": "^6.0.0"
+              }
+            },
+            "jest-haste-map": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+              "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
+              "requires": {
+                "@jest/types": "^24.9.0",
+                "anymatch": "^2.0.0",
+                "fb-watchman": "^2.0.0",
+                "fsevents": "^1.2.7",
+                "graceful-fs": "^4.1.15",
+                "invariant": "^2.2.4",
+                "jest-serializer": "^24.9.0",
+                "jest-util": "^24.9.0",
+                "jest-worker": "^24.9.0",
+                "micromatch": "^3.1.10",
+                "sane": "^4.0.3",
+                "walker": "^1.0.7"
+              }
+            },
+            "jest-message-util": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+              "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@jest/test-result": "^24.9.0",
+                "@jest/types": "^24.9.0",
+                "@types/stack-utils": "^1.0.1",
+                "chalk": "^2.0.1",
+                "micromatch": "^3.1.10",
+                "slash": "^2.0.0",
+                "stack-utils": "^1.0.1"
+              }
+            },
+            "jest-mock": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
+              "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
+              "requires": {
+                "@jest/types": "^24.9.0"
+              }
+            },
+            "jest-regex-util": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+              "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA=="
+            },
+            "jest-serializer": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
+              "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ=="
+            },
+            "jest-util": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
+              "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+              "requires": {
+                "@jest/console": "^24.9.0",
+                "@jest/fake-timers": "^24.9.0",
+                "@jest/source-map": "^24.9.0",
+                "@jest/test-result": "^24.9.0",
+                "@jest/types": "^24.9.0",
+                "callsites": "^3.0.0",
+                "chalk": "^2.0.1",
+                "graceful-fs": "^4.1.15",
+                "is-ci": "^2.0.0",
+                "mkdirp": "^0.5.1",
+                "slash": "^2.0.0",
+                "source-map": "^0.6.0"
+              }
+            },
+            "jest-worker": {
+              "version": "24.9.0",
+              "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+              "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+              "requires": {
+                "merge-stream": "^2.0.0",
+                "supports-color": "^6.1.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                  "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "jsdom": {
+              "version": "14.1.0",
+              "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-14.1.0.tgz",
+              "integrity": "sha512-O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==",
+              "requires": {
+                "abab": "^2.0.0",
+                "acorn": "^6.0.4",
+                "acorn-globals": "^4.3.0",
+                "array-equal": "^1.0.0",
+                "cssom": "^0.3.4",
+                "cssstyle": "^1.1.1",
+                "data-urls": "^1.1.0",
+                "domexception": "^1.0.1",
+                "escodegen": "^1.11.0",
+                "html-encoding-sniffer": "^1.0.2",
+                "nwsapi": "^2.1.3",
+                "parse5": "5.1.0",
+                "pn": "^1.1.0",
+                "request": "^2.88.0",
+                "request-promise-native": "^1.0.5",
+                "saxes": "^3.1.9",
+                "symbol-tree": "^3.2.2",
+                "tough-cookie": "^2.5.0",
+                "w3c-hr-time": "^1.0.1",
+                "w3c-xmlserializer": "^1.1.2",
+                "webidl-conversions": "^4.0.2",
+                "whatwg-encoding": "^1.0.5",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^7.0.0",
+                "ws": "^6.1.2",
+                "xml-name-validator": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            },
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+              "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+              "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+              "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            },
+            "slash": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+              "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+            },
+            "stack-utils": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+              "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "test-exclude": {
+              "version": "5.2.3",
+              "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+              "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+              "requires": {
+                "glob": "^7.1.3",
+                "minimatch": "^3.0.4",
+                "read-pkg-up": "^4.0.0",
+                "require-main-filename": "^2.0.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+              "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+              "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+              }
+            },
+            "write-file-atomic": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+              "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+              }
+            }
+          }
+        },
+        "jest-environment-node": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.1.0.tgz",
+          "integrity": "sha512-DNm5x1aQH0iRAe9UYAkZenuzuJ69VKzDCAYISFHQ5i9e+2Tbeu2ONGY7YStubCLH8a1wdKBgqScYw85+ySxqxg==",
+          "requires": {
+            "@jest/environment": "^26.1.0",
+            "@jest/fake-timers": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "jest-mock": "^26.1.0",
+            "jest-util": "^26.1.0"
+          }
+        },
+        "jest-fetch-mock": {
+          "version": "3.0.3",
+          "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+          "requires": {
+            "cross-fetch": "^3.0.4",
+            "promise-polyfill": "^8.1.3"
+          }
+        },
+        "jest-get-type": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+          "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg=="
+        },
+        "jest-haste-map": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.1.0.tgz",
+          "integrity": "sha512-WeBS54xCIz9twzkEdm6+vJBXgRBQfdbbXD0dk8lJh7gLihopABlJmIQFdWSDDtuDe4PRiObsjZSUjbJ1uhWEpA==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "@types/graceful-fs": "^4.1.2",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-serializer": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "jest-worker": "^26.1.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7",
+            "which": "^2.0.2"
+          }
+        },
+        "jest-jasmine2": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.1.0.tgz",
+          "integrity": "sha512-1IPtoDKOAG+MeBrKvvuxxGPJb35MTTRSDglNdWWCndCB3TIVzbLThRBkwH9P081vXLgiJHZY8Bz3yzFS803xqQ==",
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@jest/environment": "^26.1.0",
+            "@jest/source-map": "^26.1.0",
+            "@jest/test-result": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "co": "^4.6.0",
+            "expect": "^26.1.0",
+            "is-generator-fn": "^2.0.0",
+            "jest-each": "^26.1.0",
+            "jest-matcher-utils": "^26.1.0",
+            "jest-message-util": "^26.1.0",
+            "jest-runtime": "^26.1.0",
+            "jest-snapshot": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "pretty-format": "^26.1.0",
+            "throat": "^5.0.0"
+          }
+        },
+        "jest-leak-detector": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.1.0.tgz",
+          "integrity": "sha512-dsMnKF+4BVOZwvQDlgn3MG+Ns4JuLv8jNvXH56bgqrrboyCbI1rQg6EI5rs+8IYagVcfVP2yZFKfWNZy0rK0Hw==",
+          "requires": {
+            "jest-get-type": "^26.0.0",
+            "pretty-format": "^26.1.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.1.0.tgz",
+          "integrity": "sha512-PW9JtItbYvES/xLn5mYxjMd+Rk+/kIt88EfH3N7w9KeOrHWaHrdYPnVHndGbsFGRJ2d5gKtwggCvkqbFDoouQA==",
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.1.0",
+            "jest-get-type": "^26.0.0",
+            "pretty-format": "^26.1.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.1.0.tgz",
+          "integrity": "sha512-dY0+UlldiAJwNDJ08SF0HdF32g9PkbF2NRK/+2iMPU40O6q+iSn1lgog/u0UH8ksWoPv0+gNq8cjhYO2MFtT0g==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.1.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-mock": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.1.0.tgz",
+          "integrity": "sha512-1Rm8EIJ3ZFA8yCIie92UbxZWj9SuVmUGcyhLHyAhY6WI3NIct38nVcfOPWhJteqSn8V8e3xOMha9Ojfazfpovw==",
+          "requires": {
+            "@jest/types": "^26.1.0"
+          }
+        },
+        "jest-pnp-resolver": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+          "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+        },
+        "jest-regex-util": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+          "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A=="
+        },
+        "jest-resolve": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.1.0.tgz",
+          "integrity": "sha512-KsY1JV9FeVgEmwIISbZZN83RNGJ1CC+XUCikf/ZWJBX/tO4a4NvA21YixokhdR9UnmPKKAC4LafVixJBrwlmfg==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.1",
+            "jest-util": "^26.1.0",
+            "read-pkg-up": "^7.0.1",
+            "resolve": "^1.17.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-resolve-dependencies": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.1.0.tgz",
+          "integrity": "sha512-fQVEPHHQ1JjHRDxzlLU/buuQ9om+hqW6Vo928aa4b4yvq4ZHBtRSDsLdKQLuCqn5CkTVpYZ7ARh2fbA8WkRE6g==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-snapshot": "^26.1.0"
+          }
+        },
+        "jest-runner": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.1.0.tgz",
+          "integrity": "sha512-elvP7y0fVDREnfqit0zAxiXkDRSw6dgCkzPCf1XvIMnSDZ8yogmSKJf192dpOgnUVykmQXwYYJnCx641uLTgcw==",
+          "requires": {
+            "@jest/console": "^26.1.0",
+            "@jest/environment": "^26.1.0",
+            "@jest/test-result": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-config": "^26.1.0",
+            "jest-docblock": "^26.0.0",
+            "jest-haste-map": "^26.1.0",
+            "jest-jasmine2": "^26.1.0",
+            "jest-leak-detector": "^26.1.0",
+            "jest-message-util": "^26.1.0",
+            "jest-resolve": "^26.1.0",
+            "jest-runtime": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "jest-worker": "^26.1.0",
+            "source-map-support": "^0.5.6",
+            "throat": "^5.0.0"
+          }
+        },
+        "jest-runtime": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.1.0.tgz",
+          "integrity": "sha512-1qiYN+EZLmG1QV2wdEBRf+Ci8i3VSfIYLF02U18PiUDrMbhfpN/EAMMkJtT02jgJUoaEOpHAIXG6zS3QRMzRmA==",
+          "requires": {
+            "@jest/console": "^26.1.0",
+            "@jest/environment": "^26.1.0",
+            "@jest/fake-timers": "^26.1.0",
+            "@jest/globals": "^26.1.0",
+            "@jest/source-map": "^26.1.0",
+            "@jest/test-result": "^26.1.0",
+            "@jest/transform": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.2.4",
+            "jest-config": "^26.1.0",
+            "jest-haste-map": "^26.1.0",
+            "jest-message-util": "^26.1.0",
+            "jest-mock": "^26.1.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-resolve": "^26.1.0",
+            "jest-snapshot": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "jest-validate": "^26.1.0",
+            "slash": "^3.0.0",
+            "strip-bom": "^4.0.0",
+            "yargs": "^15.3.1"
+          }
+        },
+        "jest-serializer": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.1.0.tgz",
+          "integrity": "sha512-eqZOQG/0+MHmr25b2Z86g7+Kzd5dG9dhCiUoyUNJPgiqi38DqbDEOlHcNijyfZoj74soGBohKBZuJFS18YTJ5w==",
+          "requires": {
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-snapshot": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.1.0.tgz",
+          "integrity": "sha512-YhSbU7eMTVQO/iRbNs8j0mKRxGp4plo7sJ3GzOQ0IYjvsBiwg0T1o0zGQAYepza7lYHuPTrG5J2yDd0CE2YxSw==",
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^26.1.0",
+            "@types/prettier": "^2.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^26.1.0",
+            "graceful-fs": "^4.2.4",
+            "jest-diff": "^26.1.0",
+            "jest-get-type": "^26.0.0",
+            "jest-haste-map": "^26.1.0",
+            "jest-matcher-utils": "^26.1.0",
+            "jest-message-util": "^26.1.0",
+            "jest-resolve": "^26.1.0",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^26.1.0",
+            "semver": "^7.3.2"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.3.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+              "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+            }
+          }
+        },
+        "jest-util": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.1.0.tgz",
+          "integrity": "sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "jest-validate": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.1.0.tgz",
+          "integrity": "sha512-WPApOOnXsiwhZtmkDsxnpye+XLb/tUISP+H6cHjfUIXvlG+eKwP+isnivsxlHCPaO9Q5wvbhloIBkdF3qUn+Nw==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "camelcase": "^6.0.0",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^26.0.0",
+            "leven": "^3.1.0",
+            "pretty-format": "^26.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+              "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+            }
+          }
+        },
+        "jest-watcher": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.1.0.tgz",
+          "integrity": "sha512-ffEOhJl2EvAIki613oPsSG11usqnGUzIiK7MMX6hE4422aXOcVEG3ySCTDFLn1+LZNXGPE8tuJxhp8OBJ1pgzQ==",
+          "requires": {
+            "@jest/test-result": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "jest-util": "^26.1.0",
+            "string-length": "^4.0.1"
+          }
+        },
+        "jest-worker": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
+          "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
+        "jsdom": {
+          "version": "13.2.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-13.2.0.tgz",
+          "integrity": "sha512-cG1NtMWO9hWpqRNRR3dSvEQa8bFI6iLlqU2x4kwX51FQjp0qus8T9aBaAO6iGp3DeBrhdwuKxckknohkmfvsFw==",
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^6.0.4",
+            "acorn-globals": "^4.3.0",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.3.4",
+            "cssstyle": "^1.1.1",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.0",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.0.9",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.5",
+            "saxes": "^3.1.5",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^2.5.0",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^6.1.2",
+            "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+              "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+            }
+          }
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+        },
+        "kleur": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+          "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+        },
+        "leven": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+          "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+        },
+        "levenary": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+          "integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
+          "requires": {
+            "leven": "^3.1.0"
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "lines-and-columns": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+          "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          },
+          "dependencies": {
+            "parse-json": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+              "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+            }
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+        },
+        "lodash.sortby": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+          "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "requires": {
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            }
+          }
+        },
+        "makeerror": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+          "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+          "requires": {
+            "tmpl": "1.0.x"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "merge-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "mime-db": {
+          "version": "1.44.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+        },
+        "mime-types": {
+          "version": "2.1.27",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+          "requires": {
+            "mime-db": "1.44.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "mixin-deep": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+          "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "nan": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+          "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+          "optional": true
+        },
+        "nanomatch": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+          "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+          "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+        },
+        "node-int64": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+          "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+        },
+        "node-modules-regexp": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+          "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+        },
+        "node-notifier": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.2.tgz",
+          "integrity": "sha512-ux+n4hPVETuTL8+daJXTOC6uKLgMsl1RYfFv7DKRzyvzBapqco0rZZ9g72ZN8VS6V+gvNYHYa/ofcCY8fkJWsA==",
+          "optional": true,
+          "requires": {
+            "growly": "^1.3.0",
+            "is-wsl": "^2.2.0",
+            "semver": "^7.3.2",
+            "shellwords": "^0.1.1",
+            "uuid": "^8.2.0",
+            "which": "^2.0.2"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "7.3.2",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+              "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+              "optional": true
+            },
+            "uuid": {
+              "version": "8.2.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+              "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q==",
+              "optional": true
+            }
+          }
+        },
+        "node-releases": {
+          "version": "1.1.59",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.59.tgz",
+          "integrity": "sha512-H3JrdUczbdiwxN5FuJPyCHnGHIFqQ0wWxo+9j1kAXAzqNMAHlo+4I/sYYxpyK0irQ73HgdiyzD32oqQDcU2Osw=="
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "nwsapi": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+          "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "object-inspect": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+          "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.assign": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+          "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          }
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+          "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0-next.1"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "p-each-series": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+          "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ=="
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "parse5": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+          "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+          "optional": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "picomatch": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "pirates": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+          "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+          "requires": {
+            "node-modules-regexp": "^1.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "pn": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+          "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+        },
+        "pretty-format": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
+          "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+          "optional": true
+        },
+        "promise-polyfill": {
+          "version": "8.1.3",
+          "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+          "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
+        },
+        "prompts": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+          "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
+          "requires": {
+            "kleur": "^3.0.3",
+            "sisteransi": "^1.0.4"
+          }
+        },
+        "psl": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+          "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          },
+          "dependencies": {
+            "braces": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+              "optional": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "optional": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "optional": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "optional": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "optional": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "optional": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "optional": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            },
+            "to-regex-range": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+              "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+              "optional": true,
+              "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+              }
+            }
+          }
+        },
+        "realpath-native": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+          "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+          "requires": {
+            "util.promisify": "^1.0.0"
+          }
+        },
+        "regenerate": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
+          "integrity": "sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A=="
+        },
+        "regenerate-unicode-properties": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+          "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regenerator-transform": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+          "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+          "requires": {
+            "@babel/runtime": "^7.8.4"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "regexpu-core": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
+          "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^8.2.0",
+            "regjsgen": "^0.5.1",
+            "regjsparser": "^0.6.4",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.2.0"
+          }
+        },
+        "regjsgen": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+          "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A=="
+        },
+        "regjsparser": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+          "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+              "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+            }
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        },
+        "repeat-element": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+          "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "request-promise-core": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+          "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+          "requires": {
+            "lodash": "^4.17.19"
+          }
+        },
+        "request-promise-native": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+          "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+          "requires": {
+            "request-promise-core": "1.1.4",
+            "stealthy-require": "^1.1.1",
+            "tough-cookie": "^2.3.3"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-cwd": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+          "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+          "requires": {
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+        },
+        "ret": {
+          "version": "0.1.15",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "sane": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+          "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+          "requires": {
+            "@cnakazawa/watch": "^1.0.3",
+            "anymatch": "^2.0.0",
+            "capture-exit": "^2.0.0",
+            "exec-sh": "^0.3.2",
+            "execa": "^1.0.0",
+            "fb-watchman": "^2.0.0",
+            "micromatch": "^3.1.4",
+            "minimist": "^1.1.1",
+            "walker": "~1.0.5"
+          },
+          "dependencies": {
+            "anymatch": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+              "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+              "requires": {
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
+              }
+            },
+            "braces": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            },
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            },
+            "to-regex-range": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+              "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+              "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+              }
+            }
+          }
+        },
+        "saxes": {
+          "version": "3.1.11",
+          "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+          "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+          "requires": {
+            "xmlchars": "^2.1.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "set-value": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+          "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "shellwords": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+          "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+        },
+        "sisteransi": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+          "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+          "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+          "requires": {
+            "kind-of": "^3.2.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-resolve": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+          "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-support": {
+          "version": "0.5.19",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+        },
+        "spdx-correct": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+          "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+          "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+          "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        },
+        "sshpk": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+          "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "stack-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+          "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+          "requires": {
+            "escape-string-regexp": "^2.0.0"
+          },
+          "dependencies": {
+            "escape-string-regexp": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+              "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+            }
+          }
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "stealthy-require": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+          "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+        },
+        "string-length": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+          "integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+          "requires": {
+            "char-regex": "^1.0.2",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+          "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+          "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+        },
+        "strip-final-newline": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+          "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "supports-hyperlinks": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+          "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+          "requires": {
+            "has-flag": "^4.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "symbol-tree": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+          "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+        },
+        "terminal-link": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+          "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "supports-hyperlinks": "^2.0.0"
+          }
+        },
+        "test-exclude": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+          "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+          "requires": {
+            "@istanbuljs/schema": "^0.1.2",
+            "glob": "^7.1.4",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "throat": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+          "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA=="
+        },
+        "tmpl": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+          "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+        },
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+          "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+          "requires": {
+            "is-typedarray": "^1.0.0"
+          }
+        },
+        "unicode-canonical-property-names-ecmascript": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+          "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+        },
+        "unicode-match-property-ecmascript": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+          "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+          "requires": {
+            "unicode-canonical-property-names-ecmascript": "^1.0.4",
+            "unicode-property-aliases-ecmascript": "^1.0.4"
+          }
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+          "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
+        },
+        "unicode-property-aliases-ecmascript": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+          "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
+        },
+        "union-value": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+          "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^2.0.1"
+          }
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+            }
+          }
+        },
+        "upath": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+          "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+          "optional": true
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+          "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+        },
+        "use": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+          "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "optional": true
+        },
+        "util.promisify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+          "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.2",
+            "has-symbols": "^1.0.1",
+            "object.getownpropertydescriptors": "^2.1.0"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "v8-to-istanbul": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
+          "integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.1",
+            "convert-source-map": "^1.6.0",
+            "source-map": "^0.7.3"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.7.3",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+            }
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "w3c-hr-time": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+          "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+          "requires": {
+            "browser-process-hrtime": "^1.0.0"
+          }
+        },
+        "w3c-xmlserializer": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+          "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+          "requires": {
+            "domexception": "^1.0.1",
+            "webidl-conversions": "^4.0.2",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "walker": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+          "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+          "requires": {
+            "makeerror": "1.0.x"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+        },
+        "whatwg-encoding": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+          "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+          "requires": {
+            "iconv-lite": "0.4.24"
+          }
+        },
+        "whatwg-mimetype": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+          "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "window": {
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/window/-/window-4.2.6.tgz",
+          "integrity": "sha512-vk5Uv4hlPkZjUTAUVJUyvJQrbA05T99Qm3CTk0krXHKdoghxV70uPbHK3uGmrI1SfyJpdYncvZ7CbewJ30e9MQ==",
+          "requires": {
+            "jsdom": "13.2.0"
+          }
+        },
+        "word-wrap": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+          "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "write-file-atomic": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        },
+        "xml-name-validator": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+          "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+        },
+        "xmlchars": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+          "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+        },
+        "yargs": {
+          "version": "15.4.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",

--- a/scrud-nuxt/package.json
+++ b/scrud-nuxt/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "bootstrap": "^4.5.0",
     "bootstrap-vue": "^2.15.0",
+    "caching-client": "file:../cachingClient",
     "nuxt": "^2.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- [x] Wrap functionality inside a `Class`.
- [x] Extend from custom `EventTarget` (since Safari and IExplorer doesnt support the `EventTarget` constructor).
- [x] Add logic to update the cache (check cache headers to see if an update is needed for a resource).
- [x] Create events and dispatch them where is needed (update of the cache, add element to cache?).
- [x] Add tests for event handling.
- [x] Update README.
- [x] Check custom logic for `PUT`, `DELETE` and `OPTIONS` requests, and cache headers validation.

Part of #6 
Fixes #6 